### PR TITLE
feat: approveNewTransferTargets & transferToNewEscrow to allow bene and holder to transfer independently

### DIFF
--- a/contracts/ITitleEscrow.sol
+++ b/contracts/ITitleEscrow.sol
@@ -8,8 +8,11 @@ interface ITitleEscrow {
   /// @dev This emits when the ownership is transferred out of the escrow contract.
   event TitleCeded(address indexed _tokenRegistry, address indexed _to, uint256 indexed _id);
 
-  /// @dev This emits when the beneficiary endorsed the the holder's transfer.
-  event TransferEndorsed(uint256 indexed _tokenid, address indexed _from, address indexed _to);
+  /// @dev This emits when the beneficiary approves new owner for non-title escrow transfer.
+  event TransferOwnerApproval(uint256 indexed _tokenid, address indexed _from, address indexed _to);
+
+  /// @dev This emits when the beneficiary approves new beneficiary and holder for the next title escrow.
+  event TransferTitleEscrowApproval(address indexed newBeneficiary, address indexed newHolder);
 
   /// @notice Handle the receipt of an NFT
   /// @param operator The address which called `safeTransferFrom` function
@@ -26,16 +29,22 @@ interface ITitleEscrow {
   /// @param newHolder The address of the new holder
   function changeHolder(address newHolder) external;
 
-  /// @notice Handle the transfer endorsement by the beneficiary
-  /// @param newBeneficiary The address of the new holder
-  function endorseTransfer(address newBeneficiary) external;
+  /// @notice Used by beneficiary to approve an EOA or smart contract to be the next owner for the token
+  /// @param newOwner The address of the new holder
+  function approveNewOwner(address newOwner) external;
 
   /// @notice Handle the token transfer by the holder after beneficiary's endorsement
   /// @param newBeneficiary The address of the new holder
   function transferTo(address newBeneficiary) external;
 
-  /// @notice Public getter to access the endorsement if any
-  function approvedTransferTarget() external;
+  /// @notice Public getter to access the approved owner if any
+  function approvedOwner() external;
+
+  /// @notice Public getter to access the approved beneficiary if any
+  function approvedBeneficiary() external;
+
+  /// @notice Public getter to access the approved holder if any
+  function approvedHolder() external;
 
   /// @notice Public getter to access the beneficiary of the Title. The beneficiary is the legal owner of the Title.
   function beneficiary() external returns (address);
@@ -52,10 +61,15 @@ interface ITitleEscrow {
   ///@notice TokenRegistry which this TitleEscrow is registered to accept tokens from
   function tokenRegistry() external returns (address);
 
-  /// @notice Handle the token transfer by the holder after beneficiary's endorsement
+  /// @notice Used by holder to transfer token to a newly created title escrow contract
   /// @param newBeneficiary The address of the new beneficiary
   /// @param newHolder The address of the new holder
   function transferToNewEscrow(address newBeneficiary, address newHolder) external;
+
+  /// @notice Used by beneficiary to approve new beneficiary and holder to be next owners for the token
+  /// @param newBeneficiary The address of the new beneficiary
+  /// @param newHolder The address of the new holder
+  function approveNewTransferTargets(address newBeneficiary, address newHolder) external;
 }
 
 contract CalculateSelector {
@@ -64,13 +78,16 @@ contract CalculateSelector {
     return
       i.onERC721Received.selector ^
       i.changeHolder.selector ^
-      i.endorseTransfer.selector ^
+      i.approveNewOwner.selector ^
       i.transferTo.selector ^
-      i.approvedTransferTarget.selector ^
+      i.approvedOwner.selector ^
+      i.approvedBeneficiary.selector ^
+      i.approvedHolder.selector ^
       i.beneficiary.selector ^
       i.holder.selector ^
       i.status.selector ^
       i.tokenRegistry.selector ^
-      i.transferToNewEscrow.selector;
+      i.transferToNewEscrow.selector ^
+      i.approveNewTransferTargets.selector;
   }
 }

--- a/contracts/TitleEscrow.sol
+++ b/contracts/TitleEscrow.sol
@@ -12,7 +12,7 @@ contract HasNamedBeneficiary is Context {
   }
 
   modifier onlyBeneficiary() {
-    require(isBeneficiary(), "HasNamedBeneficiary: only the beneficiary may invoke a transfer");
+    require(isBeneficiary(), "HasNamedBeneficiary: only the beneficiary may invoke this function");
     _;
   }
 
@@ -49,15 +49,28 @@ contract HasHolder is Context {
 contract TitleEscrow is Context, ITitleEscrow, HasNamedBeneficiary, HasHolder, ERC165 {
   event TitleReceived(address indexed _tokenRegistry, address indexed _from, uint256 indexed _id);
   event TitleCeded(address indexed _tokenRegistry, address indexed _to, uint256 indexed _id);
-  event TransferEndorsed(uint256 indexed _tokenid, address indexed _from, address indexed _to);
+  event TransferOwnerApproval(uint256 indexed _tokenid, address indexed _from, address indexed _to);
+  event TransferTitleEscrowApproval(address indexed newBeneficiary, address indexed newHolder);
+
+  // ERC165: Interface for this contract, can be calculated by calculateSelector()
+  bytes4 private constant _INTERFACE_ID_TITLEESCROW = 0xdcce2211;
 
   enum StatusTypes {Uninitialised, InUse, Exited}
+  StatusTypes public status = StatusTypes.Uninitialised;
+
+  // Information on token held
   ERC721 public tokenRegistry;
   uint256 public _tokenId;
-  address public approvedTransferTarget = address(0);
-  StatusTypes public status = StatusTypes.Uninitialised;
-  bytes4 private constant _INTERFACE_ID_TITLEESCROW = 0xd9841dc4;
+
+  // Factory to clone this title escrow
   ITitleEscrowCreator public titleEscrowFactory;
+
+  // For exiting into title escrow contracts
+  address public approvedBeneficiary;
+  address public approvedHolder;
+
+  // For exiting into non-title escrow contracts
+  address public approvedOwner;
 
   //TODO: change ERC721 to address so that external contracts don't need to import ERC721 to use this
   constructor(ERC721 _tokenRegistry, address _beneficiary, address _holder, address _titleEscrowFactoryAddress)
@@ -89,13 +102,20 @@ contract TitleEscrow is Context, ITitleEscrow, HasNamedBeneficiary, HasHolder, E
     _changeHolder(newHolder);
   }
 
-  modifier allowTransfer(address newBeneficiary) {
-    require(newBeneficiary != address(0), "TitleEscrow: Transferring to 0x0 is not allowed");
+  modifier allowTransferOwner(address newOwner) {
+    require(newOwner != address(0), "TitleEscrow: Transferring to 0x0 is not allowed");
     if (holder != beneficiary) {
-      require(
-        newBeneficiary == approvedTransferTarget,
-        "TitleEscrow: Transfer target has not been endorsed by beneficiary"
-      );
+      require(newOwner == approvedOwner, "TitleEscrow: New owner has not been approved by beneficiary");
+    }
+    _;
+  }
+
+  modifier allowTransferTitleEscrow(address newBeneficiary, address newHolder) {
+    require(newBeneficiary != address(0), "TitleEscrow: Transferring to 0x0 is not allowed");
+    require(newHolder != address(0), "TitleEscrow: Transferring to 0x0 is not allowed");
+    if (holder != beneficiary) {
+      require(newBeneficiary == approvedBeneficiary, "TitleEscrow: Beneficiary has not been endorsed by beneficiary");
+      require(newHolder == approvedHolder, "TitleEscrow: Holder has not been endorsed by beneficiary");
     }
     _;
   }
@@ -107,28 +127,43 @@ contract TitleEscrow is Context, ITitleEscrow, HasNamedBeneficiary, HasHolder, E
     _;
   }
 
-  function endorseTransfer(address newBeneficiary) public isHoldingToken onlyBeneficiary {
-    emit TransferEndorsed(_tokenId, beneficiary, newBeneficiary);
-    approvedTransferTarget = newBeneficiary;
+  function approveNewOwner(address newOwner) public isHoldingToken onlyBeneficiary {
+    emit TransferOwnerApproval(_tokenId, beneficiary, newOwner);
+    approvedOwner = newOwner;
   }
 
-  function transferTo(address newBeneficiary) public isHoldingToken onlyHolder allowTransfer(newBeneficiary) {
+  function _transferTo(address newOwner) private {
     status = StatusTypes.Exited;
-    emit TitleCeded(address(tokenRegistry), newBeneficiary, _tokenId);
-    tokenRegistry.safeTransferFrom(address(this), address(newBeneficiary), _tokenId);
+    emit TitleCeded(address(tokenRegistry), newOwner, _tokenId);
+    tokenRegistry.safeTransferFrom(address(this), address(newOwner), _tokenId);
+  }
+
+  function transferTo(address newOwner) public isHoldingToken onlyHolder allowTransferOwner(newOwner) {
+    _transferTo(newOwner);
   }
 
   function transferToNewEscrow(address newBeneficiary, address newHolder)
     public
     isHoldingToken
     onlyHolder
-    allowTransfer(newBeneficiary)
+    allowTransferTitleEscrow(newBeneficiary, newHolder)
   {
     address newTitleEscrowAddress = titleEscrowFactory.deployNewTitleEscrow(
       address(tokenRegistry),
       newBeneficiary,
       newHolder
     );
-    transferTo(newTitleEscrowAddress);
+    _transferTo(newTitleEscrowAddress);
+  }
+
+  function approveNewTransferTargets(address newBeneficiary, address newHolder) public onlyBeneficiary isHoldingToken {
+    require(newBeneficiary != address(0), "TitleEscrow: Transferring to 0x0 is not allowed");
+    require(newHolder != address(0), "TitleEscrow: Transferring to 0x0 is not allowed");
+
+    emit TransferTitleEscrowApproval(newBeneficiary, newHolder);
+
+    approvedBeneficiary = newBeneficiary;
+    approvedHolder = newHolder;
+
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3345,6 +3345,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3352,7 +3353,8 @@
     "@types/node": {
       "version": "10.14.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
-      "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ=="
+      "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3369,12 +3371,14 @@
     "@types/prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ=="
+      "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+      "dev": true
     },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
       "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3517,6 +3521,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -3546,7 +3551,8 @@
     "app-module-path": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -3588,6 +3594,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+      "dev": true,
       "requires": {
         "typical": "^2.6.1"
       }
@@ -3979,7 +3986,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -4085,6 +4093,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4314,6 +4323,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -4323,12 +4333,14 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -4556,6 +4568,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -4563,7 +4576,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colors": {
       "version": "1.4.0",
@@ -4584,6 +4598,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
       "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "find-replace": "^1.0.3",
@@ -4700,7 +4715,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "confusing-browser-globals": {
       "version": "1.0.7",
@@ -5086,6 +5102,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -5242,7 +5259,8 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "25.1.0",
@@ -5517,7 +5535,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.1",
@@ -6392,6 +6411,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "dev": true,
       "requires": {
         "array-back": "^1.0.4",
         "test-value": "^2.1.0"
@@ -6401,6 +6421,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -6856,7 +6877,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.9",
@@ -8285,6 +8307,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -8387,7 +8410,8 @@
     "graceful-fs": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
+      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.3",
@@ -8541,7 +8565,8 @@
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -8715,6 +8740,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -8723,7 +8749,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -11060,6 +11087,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -11194,7 +11222,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -11670,6 +11699,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11677,7 +11707,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -11760,7 +11791,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -15740,6 +15772,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -15788,7 +15821,8 @@
     "original-require": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
-      "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
+      "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA=",
+      "dev": true
     },
     "os-name": {
       "version": "3.1.0",
@@ -15949,7 +15983,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -15966,7 +16001,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -16081,7 +16117,8 @@
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -16948,6 +16985,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -18668,6 +18706,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+      "dev": true,
       "requires": {
         "array-back": "^1.0.3",
         "typical": "^2.6.0"
@@ -18677,6 +18716,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -18829,6 +18869,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.3.tgz",
       "integrity": "sha512-fCL0pGCvBWPboyl3dzgAZFSgpBsgb5NdaaIXbouuqGxFjfgq5+JK2PZLEgN/GYBF+uEzcYg83hFOHCHlZJZINw==",
+      "dev": true,
       "requires": {
         "app-module-path": "^2.2.0",
         "mocha": "5.2.0",
@@ -18838,27 +18879,32 @@
         "browser-stdout": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+          "dev": true
         },
         "commander": {
           "version": "2.15.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
         },
         "growl": {
           "version": "1.10.5",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -18867,6 +18913,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
           "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+          "dev": true,
           "requires": {
             "browser-stdout": "1.3.1",
             "commander": "2.15.1",
@@ -18885,6 +18932,7 @@
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18894,12 +18942,14 @@
     "ts-essentials": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
-      "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ=="
+      "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==",
+      "dev": true
     },
     "ts-generator": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ts-generator/-/ts-generator-0.0.8.tgz",
       "integrity": "sha512-Gi+aZCELpVL7Mqb+GuMgM+n8JZ/arZZib1iD/R9Ok8JDjOCOCrqS9b1lr72ku7J45WeDCFZxyJoRsiQvhokCnw==",
+      "dev": true,
       "requires": {
         "@types/mkdirp": "^0.5.2",
         "@types/prettier": "^1.13.2",
@@ -18915,12 +18965,14 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
           "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -18973,6 +19025,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/typechain/-/typechain-1.0.5.tgz",
       "integrity": "sha512-gbQmJXPKuYQ0p3tK+dMhpdQql/UPtSnkPQXw2QM/aqwCengI86z2vEM2e5rVQpmk/blFx1PYNdApSDxE12rR1Q==",
+      "dev": true,
       "requires": {
         "command-line-args": "^4.0.7",
         "debug": "^3.0.1",
@@ -18986,6 +19039,7 @@
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -18995,7 +19049,8 @@
         "js-sha3": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+          "dev": true
         }
       }
     },
@@ -19003,6 +19058,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typechain-target-ethers/-/typechain-target-ethers-1.0.4.tgz",
       "integrity": "sha512-ay4qcan8erubMgBUcMErKplwQXydWCo/mBmrYGfbnnbUYzRe99jGs4uuSEi1JH2jGDtRi1sRDpIW0q9V4fd14A==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -19025,7 +19081,8 @@
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.8.0",
@@ -19108,7 +19165,8 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -19584,7 +19642,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/scripts/postInstall.js
+++ b/scripts/postInstall.js
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-var-requires,no-console */
 const fs = require("fs");
 const path = require("path");
 const {execSync} = require("child_process");

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -76,8 +76,8 @@ describe("TitleEscrowFactory", () => {
   it("should be able to write to TitleEscrow", async () => {
     const escrowInstance = await deployTitleEscrow();
     await tokenRegistry.safeMint(escrowInstance.address, tokenId, []);
-    await escrowInstance.endorseTransfer(account2);
-    const target = await escrowInstance.approvedTransferTarget();
+    await escrowInstance.approveNewOwner(account2);
+    const target = await escrowInstance.approvedOwner();
     expect(target).toBe(account2);
   });
 });

--- a/test/TitleEscrow.js
+++ b/test/TitleEscrow.js
@@ -22,8 +22,8 @@ const assertTitleCededLog = (log, tokenRegistry, receiver) => {
   expect(log.args[0]).to.deep.equal(tokenRegistry);
   expect(log.args[1]).to.deep.equal(receiver);
 };
-const assertTransferEndorsedLog = (log, sender, receiver) => {
-  expect(log.event).to.deep.equal("TransferEndorsed");
+const assertTransferOwnerApprovalLog = (log, sender, receiver) => {
+  expect(log.event).to.deep.equal("TransferOwnerApproval");
   expect(log.args[1]).to.deep.equal(sender);
   expect(log.args[2]).to.deep.equal(receiver);
 };
@@ -65,7 +65,7 @@ contract("TitleEscrow", accounts => {
     const calculatorInstance = await CalculateSelector.new();
     const expectedInterface = await calculatorInstance.calculateSelector();
     const interfaceSupported = await escrowInstance.supportsInterface(expectedInterface);
-    expect(interfaceSupported).to.be.equal(true);
+    expect(interfaceSupported).to.be.equal(true, `Expected selector: ${expectedInterface}`);
   });
 
   it("should be instantiated correctly when deployed by 3rd party to be held by beneficiary1", async () => {
@@ -99,11 +99,11 @@ contract("TitleEscrow", accounts => {
       from: carrier1
     });
 
-    const endorseTransferTx = escrowInstance.endorseTransfer(beneficiary2, {
+    const approveNewOwnerTx = escrowInstance.approveNewOwner(beneficiary2, {
       from: beneficiary1
     });
 
-    await expect(endorseTransferTx).to.be.rejectedWith(/TitleEscrow: Contract is not holding a token/);
+    await expect(approveNewOwnerTx).to.be.rejectedWith(/TitleEscrow: Contract is not holding a token/);
     const changeHolderTx = escrowInstance.changeHolder(holder2, {
       from: holder1
     });
@@ -190,9 +190,9 @@ contract("TitleEscrow", accounts => {
 
     expect(await escrowInstance.holder()).to.be.equal(holder1);
 
-    const approveEndorseTransferTx = await escrowInstance.endorseTransfer(beneficiary2, {from: beneficiary1});
+    const approveapproveNewOwnerTx = await escrowInstance.approveNewOwner(beneficiary2, {from: beneficiary1});
 
-    assertTransferEndorsedLog(approveEndorseTransferTx.logs[0], beneficiary1, beneficiary2);
+    assertTransferOwnerApprovalLog(approveapproveNewOwnerTx.logs[0], beneficiary1, beneficiary2);
 
     const tranferOwnerTx = await escrowInstance.transferTo(beneficiary2, {
       from: holder1
@@ -251,7 +251,7 @@ contract("TitleEscrow", accounts => {
     });
 
     await expect(attemptToTransferOwnerTx).to.be.rejectedWith(
-      /TitleEscrow: Transfer target has not been endorsed by beneficiary/
+      /TitleEscrow: New owner has not been approved by beneficiary/
     );
   });
   it("should not allow unauthorised party to execute any state change", async () => {
@@ -272,12 +272,12 @@ contract("TitleEscrow", accounts => {
     });
 
     await expect(attemptToTransferHolderTx).to.be.rejectedWith(/HasHolder: only the holder may invoke this function/);
-    const attemptToEndorseTransferTx = escrowInstance.endorseTransfer(holder2, {
+    const attemptToapproveNewOwnerTx = escrowInstance.approveNewOwner(holder2, {
       from: beneficiary2
     });
 
-    await expect(attemptToEndorseTransferTx).to.be.rejectedWith(
-      /HasNamedBeneficiary: only the beneficiary may invoke a transfer/
+    await expect(attemptToapproveNewOwnerTx).to.be.rejectedWith(
+      /HasNamedBeneficiary: only the beneficiary may invoke this function/
     );
   });
 
@@ -356,5 +356,182 @@ contract("TitleEscrow", accounts => {
     expect(escrowBeneficiary).to.be.equal(beneficiary2);
     expect(escrowHolder).to.be.equal(holder2);
     expect(escrowTokenRegistry).to.be.equal(ERC721Address);
+  });
+
+  it("should allow current beneficiary to appoint new beneficiary and holder as the transfer target", async () => {
+    const titleEscrowCreatorInstance = await TitleEscrowCreator.new();
+    const escrowInstance = await TitleEscrow.new(
+      ERC721Address,
+      beneficiary1,
+      holder1,
+      titleEscrowCreatorInstance.address,
+      {
+        from: beneficiary1
+      }
+    );
+
+    await ERC721Instance.safeMint(escrowInstance.address, SAMPLE_TOKEN_ID);
+
+    const prevApprovedBeneficiary = await escrowInstance.approvedBeneficiary();
+    const prevApprovedHolder = await escrowInstance.approvedHolder();
+    expect(prevApprovedBeneficiary).to.be.equal(ZERO_ADDRESS);
+    expect(prevApprovedHolder).to.be.equal(ZERO_ADDRESS);
+
+    // Execute the transaction to name new beneficiary & holder
+    const receipt = await escrowInstance.approveNewTransferTargets(beneficiary2, holder2, {from: beneficiary1});
+    expect(receipt.logs[0].args.newBeneficiary).to.be.equal(beneficiary2);
+    expect(receipt.logs[0].args.newHolder).to.be.equal(holder2);
+
+    const afterApprovedBeneficiary = await escrowInstance.approvedBeneficiary();
+    const afterApprovedHolder = await escrowInstance.approvedHolder();
+    expect(afterApprovedBeneficiary).to.be.equal(beneficiary2);
+    expect(afterApprovedHolder).to.be.equal(holder2);
+  });
+
+  it("should not allow current beneficiary to appoint new beneficiary and holder when the contract is not the owner of a token", async () => {
+    const titleEscrowCreatorInstance = await TitleEscrowCreator.new();
+    const escrowInstance = await TitleEscrow.new(
+      ERC721Address,
+      beneficiary1,
+      holder1,
+      titleEscrowCreatorInstance.address,
+      {
+        from: beneficiary1
+      }
+    );
+
+    const attemptToTransfer = escrowInstance.approveNewTransferTargets(beneficiary2, holder2, {from: beneficiary1});
+
+    await expect(attemptToTransfer).to.be.rejectedWith(/TitleEscrow: Contract is not holding a token/);
+  });
+
+  it("should not allow user to appoint new beneficiary and holder when user is not the beneficiary", async () => {
+    const titleEscrowCreatorInstance = await TitleEscrowCreator.new();
+    const escrowInstance = await TitleEscrow.new(
+      ERC721Address,
+      beneficiary1,
+      holder1,
+      titleEscrowCreatorInstance.address,
+      {
+        from: beneficiary1
+      }
+    );
+
+    await ERC721Instance.safeMint(escrowInstance.address, SAMPLE_TOKEN_ID);
+
+    const attemptToAppoint = escrowInstance.approveNewTransferTargets(beneficiary2, holder2, {from: carrier1});
+
+    await expect(attemptToAppoint).to.be.rejectedWith(
+      /HasNamedBeneficiary: only the beneficiary may invoke this function/
+    );
+  });
+
+  it("should allow holder to execute transferToNewEscrow when new beneficiary and holder has been appointed by beneficiary", async () => {
+    const titleEscrowCreatorInstance = await TitleEscrowCreator.new();
+    const escrowInstance = await TitleEscrow.new(
+      ERC721Address,
+      beneficiary1,
+      holder1,
+      titleEscrowCreatorInstance.address,
+      {
+        from: beneficiary1
+      }
+    );
+
+    await ERC721Instance.safeMint(escrowInstance.address, SAMPLE_TOKEN_ID);
+
+    await escrowInstance.approveNewTransferTargets(beneficiary2, holder2, {from: beneficiary1});
+
+    await escrowInstance.transferToNewEscrow(beneficiary2, holder2, {from: holder1});
+
+    // Make sure the transfer really has happened
+    const ownerOnRegistry = await ERC721Instance.ownerOf(SAMPLE_TOKEN_ID);
+    const newEscrowInstance = await TitleEscrow.at(ownerOnRegistry);
+    const escrowBeneficiary = await newEscrowInstance.beneficiary();
+    const escrowHolder = await newEscrowInstance.holder();
+    const escrowTokenRegistry = await newEscrowInstance.tokenRegistry();
+    expect(escrowBeneficiary).to.be.equal(beneficiary2);
+    expect(escrowHolder).to.be.equal(holder2);
+    expect(escrowTokenRegistry).to.be.equal(ERC721Address);
+  });
+
+  it("should not allow holder to execute transferToNewEscrow when new beneficiary and holder has not been appointed", async () => {
+    const titleEscrowCreatorInstance = await TitleEscrowCreator.new();
+    const escrowInstance = await TitleEscrow.new(
+      ERC721Address,
+      beneficiary1,
+      holder1,
+      titleEscrowCreatorInstance.address,
+      {
+        from: beneficiary1
+      }
+    );
+
+    await ERC721Instance.safeMint(escrowInstance.address, SAMPLE_TOKEN_ID);
+
+    const attemptToTransfer = escrowInstance.transferToNewEscrow(beneficiary2, holder2, {from: holder1});
+
+    await expect(attemptToTransfer).to.be.rejectedWith(/TitleEscrow: Beneficiary has not been endorsed by beneficiary/);
+  });
+
+  it("should not allow anyone else (esp beneficiary) to execute transferToNewEscrow when new beneficiary and holder has been appointed", async () => {
+    const titleEscrowCreatorInstance = await TitleEscrowCreator.new();
+    const escrowInstance = await TitleEscrow.new(
+      ERC721Address,
+      beneficiary1,
+      holder1,
+      titleEscrowCreatorInstance.address,
+      {
+        from: beneficiary1
+      }
+    );
+
+    await ERC721Instance.safeMint(escrowInstance.address, SAMPLE_TOKEN_ID);
+
+    const attemptToTransferByBeneficiay = escrowInstance.transferToNewEscrow(beneficiary2, holder2, {
+      from: beneficiary1
+    });
+    await expect(attemptToTransferByBeneficiay).to.be.rejectedWith(
+      /HasHolder: only the holder may invoke this function/
+    );
+
+    const attemptToTransferByCarrier = escrowInstance.transferToNewEscrow(beneficiary2, holder2, {from: carrier1});
+    await expect(attemptToTransferByCarrier).to.be.rejectedWith(/HasHolder: only the holder may invoke this function/);
+  });
+
+  it("should not allow holder to execute transferToNewEscrow to other targets not appointed by beneficiary", async () => {
+    const titleEscrowCreatorInstance = await TitleEscrowCreator.new();
+    const escrowInstance = await TitleEscrow.new(
+      ERC721Address,
+      beneficiary1,
+      holder1,
+      titleEscrowCreatorInstance.address,
+      {
+        from: beneficiary1
+      }
+    );
+
+    await ERC721Instance.safeMint(escrowInstance.address, SAMPLE_TOKEN_ID);
+
+    await escrowInstance.approveNewTransferTargets(beneficiary2, holder2, {from: beneficiary1});
+
+    const attemptToTransfer = escrowInstance.transferToNewEscrow(carrier1, carrier1, {from: holder1});
+
+    await expect(attemptToTransfer).to.be.rejectedWith(/TitleEscrow: Beneficiary has not been endorsed by beneficiary/);
+  });
+
+  it("should not allow _transferTo to be called by any user", async () => {
+    const titleEscrowCreatorInstance = await TitleEscrowCreator.new();
+    const escrowInstance = await TitleEscrow.new(
+      ERC721Address,
+      beneficiary1,
+      holder1,
+      titleEscrowCreatorInstance.address,
+      {
+        from: beneficiary1
+      }
+    );
+    // eslint-disable-next-line no-underscore-dangle
+    expect(escrowInstance._transferTo).to.be.undefined;
   });
 });


### PR DESCRIPTION
## Summary

Adds new function `approveNewTransferTargets` for current beneficiary to approve transfer to a beneficiary and holder. This allows the holder to execute `transferToNewEscrow` with the same beneficiary and holder (needed the two parameter to prevent front-running attacks). 

## Done
- Added new function `approveNewTransferTargets`
- Modified `transferToNewEscrow` to use the modifier `allowTransferTitleEscrow(newBeneficiary, newHolder)` to check if the the user can execute the transaction
- Refactor the nomenclatures of the entire contract to distinguish transfer to title escrow contracts (w Beneficiary & Holder) and non title escrow contracts (just Owner). 