### PR TITLE
feat: destroyToken transfer to 0xdead

### DIFF
--- a/contracts/ERC721.sol
+++ b/contracts/ERC721.sol
@@ -1247,7 +1247,8 @@ contract TradeTrustERC721 is ERC721MintableFull, IERC721Receiver {
 
   function destroyToken(uint256 _tokenId) public onlyMinter {
     require(ownerOf(_tokenId) == address(this), "Cannot destroy token: Token not owned by token registry");
-    _burn(_tokenId);
+    // Burning token to 0xdead instead to show a differentiate state as address(0) is used for unminted tokens
+    _safeTransferFrom(ownerOf(_tokenId), 0x000000000000000000000000000000000000dEaD, _tokenId, "");
     emit TokenBurnt(_tokenId);
   }
 


### PR DESCRIPTION
This PR changes burn address to 0xdead instead of 0x0 from the discussion:

### using 0x0 as burn address
Pros:
+ semantically correct because it is not owned by anyone anymore
+ not needing to inform consumers of a burn address

Cons:
- difficult to implement because surrendered still needs to be render-able and we can only tell this by checking the history of the token transfers
- event emission might be lost in future (they were asking people not to do event sourced state from events at devcon), and state is not immediately available to be queried

### using 0xknown as burn address
Pros:
+ easy to implement
+ known dead address are available and labeled
+ state is immediately available to be queried

Cons:
- it's a convention that needs to be propagated
- it's not possible to prove to another party that this address is uncontrolled