### PR TITLE
fix: build types

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -19,6 +19,7 @@ module.exports = {
   },
   typechain: {
     outDir: "src/contracts",
+    alwaysGenerateOverloads: true,
   },
   watcher: {
     test: {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "files": [
     "dist",
     "src",
-    "scripts",
-    "types"
+    "scripts"
   ],
   "main": "dist/index.js",
-  "types": "dist/ts/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "repository": "git@github.com:Open-Attestation/token-registry.git",
   "author": "GovTech",
   "license": "Apache-2.0",
@@ -16,8 +15,9 @@
     "build:sol": "hardhat compile",
     "build:js:copy-src": "babel src -d dist --ignore src/**/*.spec.ts,src/**/*.test.ts -x .js,.ts,.tsx --copy-files",
     "build:js": "tsc --emitDeclarationOnly && npm run build:js:copy-src",
-    "build": "npm run build:sol && npm run copy-types && npm run build:js",
-    "copy-types": "rm -rf types && mkdir -p types && cp src/contracts/*.d.ts types/ && mkdir -p dist/ts/contracts && cp src/contracts/*.d.ts dist/ts/contracts",
+    "build:js:copy-types": "mkdir -p ./dist/types && cp ./src/contracts/*.d.ts ./dist/types/contracts",
+    "build": "npm run clean:build && npm run build:sol && npm run build:js && npm run build:js:copy-types",
+    "clean:build": "rm -rf ./dist && rm -rf build && rm -rf ./src/contracts",
     "commit": "git-cz",
     "commit:retry": "npm run commit -- --retry",
     "lint:js": "eslint test src --ext .js --ext .ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,11 @@
 import { providers } from "ethers";
-import { TitleEscrowCloneableFactory, TradeTrustErc721Factory, TitleEscrowClonerFactory } from "./index";
-import { TradeTrustERC721 } from "../types/TradeTrustERC721";
-import { TitleEscrowCloner } from "../types/TitleEscrowCloner";
+import {
+  TitleEscrowCloneable__factory as TitleEscrowCloneableFactory,
+  TradeTrustERC721__factory as TradeTrustERC721Factory,
+  TitleEscrowCloner__factory as TitleEscrowClonerFactory,
+  TradeTrustERC721,
+  TitleEscrowCloner,
+} from "./contracts";
 
 const provider = new providers.JsonRpcProvider();
 const signer1 = provider.getSigner(0);
@@ -22,7 +26,7 @@ describe("TitleEscrowClonerFactory", () => {
   beforeEach(async () => {
     const factory = new TitleEscrowClonerFactory(signer1);
     titleEscrowFactory = await factory.deploy();
-    const tokenRegistryFactory = new TradeTrustErc721Factory(signer1);
+    const tokenRegistryFactory = new TradeTrustERC721Factory(signer1);
     tokenRegistry = await tokenRegistryFactory.deploy("MY_TOKEN_REGISTRY", "TKN");
   });
 
@@ -45,7 +49,7 @@ describe("TitleEscrowCloneableFactory", () => {
   let tokenRegistry: TradeTrustERC721;
 
   beforeEach(async () => {
-    const tokenRegistryFactory = new TradeTrustErc721Factory(signer1);
+    const tokenRegistryFactory = new TradeTrustERC721Factory(signer1);
     tokenRegistry = await tokenRegistryFactory.deploy("MY_TOKEN_REGISTRY", "TKN");
   });
 
@@ -89,7 +93,7 @@ describe("TitleEscrowCloneableFactory", () => {
 
 describe("TradeTrustErc721Factory", () => {
   const deployTradeTrustERC721 = async () => {
-    const factory = new TradeTrustErc721Factory(signer1);
+    const factory = new TradeTrustERC721Factory(signer1);
     const registryInstance = await factory.deploy("TOKEN_REGISTRY_NAME", "TKN");
     return registryInstance;
   };
@@ -101,7 +105,7 @@ describe("TradeTrustErc721Factory", () => {
   });
   it("should be able to connect to an existing TradeTrustERC721", async () => {
     const deployedInstance = await deployTradeTrustERC721();
-    const instance = await TradeTrustErc721Factory.connect(deployedInstance.address, signer1);
+    const instance = await TradeTrustERC721Factory.connect(deployedInstance.address, signer1);
     const sym = await instance.symbol();
     expect(sym).toBe("TKN");
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,8 @@
 export {
   TitleEscrowCloneable__factory as TitleEscrowCloneableFactory,
   TitleEscrowCloner__factory as TitleEscrowClonerFactory,
-  TradeTrustERC721__factory as TradeTrustErc721Factory,
+  TradeTrustERC721__factory as TradeTrustERC721Factory,
+  TitleEscrowCloneable,
+  TitleEscrowCloner,
+  TradeTrustERC721,
 } from "./contracts";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "dist/ts",
+    "outDir": "dist/types",
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
## Summary
The current build setup requires projects importing the contract objects from either the src or types folder. For instance, importing the registry would require one to do this:
```
import { TradeTrustERC721 } from "@govtechsg/token-registry/types/TradeTrustErc721";
import { TitleEscrowCloneable } from "@govtechsg/token-registry/types/TitleEscrowCloneable";
```
This PR attempts to correct this issue so that projects can import directly from the package without having to know where it's located in the types or src folder.
```
import { TradeTrustERC721, TitleEscrowCloneable } from "@govtechsg/token-registry";
```

## Changes
- Corrected the build path for the types
- Added build clean up

## Issues
Related to https://github.com/Open-Attestation/document-store/issues/98