### PR TITLE
feat: restore to owner in previous title escrow

### DIFF
--- a/contracts/TitleEscrowCloneable.sol
+++ b/contracts/TitleEscrowCloneable.sol
@@ -8,7 +8,6 @@ import "./interfaces/ITitleEscrow.sol";
 import "./lib/Initializable.sol";
 import { ERC721, ERC165 } from "./lib/ERC721.sol";
 
-
 contract TitleEscrowCloneable is Context, Initializable, ITitleEscrow, HasHolderInitializable, HasNamedBeneficiaryInitializable, ERC165  {
   // Documentation on how this smart contract works: https://docs.tradetrust.io/docs/overview/title-transfer
 
@@ -104,6 +103,10 @@ contract TitleEscrowCloneable is Context, Initializable, ITitleEscrow, HasHolder
 
   function transferTo(address newOwner) public override isHoldingToken onlyHolder allowTransferOwner(newOwner) {
     _transferTo(newOwner);
+  }
+
+  function surrender() external isHoldingToken onlyBeneficiary onlyHolder {
+    _transferTo(address(tokenRegistry));
   }
 
   function transferToNewEscrow(address newBeneficiary, address newHolder)

--- a/contracts/TitleEscrowCloneable.sol
+++ b/contracts/TitleEscrowCloneable.sol
@@ -100,7 +100,7 @@ contract TitleEscrowCloneable is Context, Initializable, ITitleEscrow, HasHolder
     emit TitleCeded(address(tokenRegistry), newOwner, _tokenId);
     tokenRegistry.safeTransferFrom(address(this), address(newOwner), _tokenId);
   }
-
+  
   function transferTo(address newOwner) public override isHoldingToken onlyHolder allowTransferOwner(newOwner) {
     _transferTo(newOwner);
   }

--- a/contracts/TradetrustERC721.sol
+++ b/contracts/TradetrustERC721.sol
@@ -12,6 +12,9 @@ contract TradeTrustERC721 is TitleEscrowCloner, ERC721Mintable, IERC721Receiver 
   event TokenBurnt(uint256 indexed tokenId);
   event TokenReceived(address indexed operator, address indexed from, uint256 indexed tokenId, bytes data);
 
+  // Mapping from token ID to previously surrendered title escrow address
+  mapping(uint => address) private _surrenderedOwners;
+
   constructor(string memory name, string memory symbol) ERC721Mintable(name, symbol) {return;}
 
   function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721Mintable) returns (bool) {
@@ -34,20 +37,29 @@ contract TradeTrustERC721 is TitleEscrowCloner, ERC721Mintable, IERC721Receiver 
   function destroyToken(uint256 tokenId) external onlyMinter {
     require(ownerOf(tokenId) == address(this), "TokenRegistry: Token has not been surrendered");
 
-    // Burning token to 0xdead instead to show a differentiate state as address(0) is used for unminted tokens
     emit TokenBurnt(tokenId);
+
+    // Remove the last surrendered token owner
+    delete _surrenderedOwners[tokenId];
+
+    // Burning token to 0xdead instead to show a differentiate state as address(0) is used for unminted tokens
     _registrySafeTransformFrom(ownerOf(tokenId), 0x000000000000000000000000000000000000dEaD, tokenId);
   }
 
   function restoreTitle(
-    address beneficiary,
-    address holder,
     uint256 tokenId
   ) external onlyMinter returns (address) {
     require(_exists(tokenId), "TokenRegistry: Token does not exist");
-    require(ownerOf(tokenId) == address(this), "TokenRegistry: Token is not owned by registry");
+    require(ownerOf(tokenId) == address(this) && _surrenderedOwners[tokenId] != address(0), "TokenRegistry: Token is not surrendered");
 
+    ITitleEscrow titleEscrow = ITitleEscrow(_surrenderedOwners[tokenId]);
+    address beneficiary = titleEscrow.beneficiary();
+    address holder = titleEscrow.holder();
     address newTitleEscrow = _deployNewTitleEscrow(address(this), beneficiary, holder);
+
+    // Remove the last surrendered token owner
+    delete _surrenderedOwners[tokenId];
+
     _registrySafeTransformFrom(address(this), newTitleEscrow, tokenId);
 
     return newTitleEscrow;
@@ -64,6 +76,18 @@ contract TradeTrustERC721 is TitleEscrowCloner, ERC721Mintable, IERC721Receiver 
     _safeMint(newTitleEscrow, tokenId);
 
     return newTitleEscrow;
+  }
+
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 tokenId
+  ) internal virtual override {
+    if (to == address(this)) {
+      // Surrendering, hence, store the current owner
+      _surrenderedOwners[tokenId] = from;
+    }
+    super._beforeTokenTransfer(from, to, tokenId);
   }
 
   function _registrySafeTransformFrom(


### PR DESCRIPTION
## Summary
In v2.x, we relied on the `deployNewTitleEscrow` and `sendToNewTitleEscrow` function to manually restore title escrows. The minter was able deploy a new title escrow with any new owners to it. In a more recent v3 update, we've refactored the function to become `restoreTitle` so that the deployment of the title escrow is automated within the function and it is easier to just make a single call to restore a title escrow. But this still allows the minter to restore to arbitrary new owners.

Since the business intention is to reject the document, it should return to the original owner in the previous title escrow. The minter should not be able to restore to any new owners he/she wants in a new title escrow. 

## Changes
* Add mapping of token ID to previously surrendered title escrows
* Retrieve owner addresses from previous title escrows during restoration
* Update test cases

## Issues
https://www.pivotaltracker.com/story/show/179989792

## Releases
Channel: beta