### PR TITLE
fix: surrender status for accepted tokens

### DIFF
--- a/contracts/TradeTrustERC721Base.sol
+++ b/contracts/TradeTrustERC721Base.sol
@@ -106,7 +106,8 @@ abstract contract TradeTrustERC721Base is MinterRole, TitleEscrowCloner, IERC721
 
   function isSurrendered(uint256 tokenId) public view returns (bool) {
     if (_exists(tokenId)) {
-      return ownerOf(tokenId) == address(this) && _surrenderedOwners[tokenId] != address(0);
+      address owner = ownerOf(tokenId);
+      return (owner == address(this) && _surrenderedOwners[tokenId] != address(0)) || owner == BURN_ADDRESS;
     }
     return false;
   }


### PR DESCRIPTION
## Summary
The surrendered status returned false after a token has been accepted because the token ID no longer exists. This PR fixes this so that `isSurrendered` returns true for tokens that have been surrendered as well as those that have been subsequently accepted.

## Changes
* Fix `isSurrendered` for accepted tokens
* Add tests coverage for `isSurrendered`

## Issues
* https://github.com/Open-Attestation/token-registry-subgraph/pull/8

## Releases
Channels: beta
