### PR TITLE
feat: streamline mint functions

### DIFF
--- a/contracts/TradetrustERC721.sol
+++ b/contracts/TradetrustERC721.sol
@@ -6,19 +6,20 @@ import "./TitleEscrowCloner.sol";
 import "./interfaces/ITitleEscrowCreator.sol";
 import "./interfaces/ITitleEscrow.sol";
 import "./interfaces/ITradeTrustERC721.sol";
-import { ERC721Mintable, IERC721Receiver } from "./lib/ERC721.sol";
+import { ERC721, IERC721Receiver, MinterRole } from "./lib/ERC721.sol";
 
-contract TradeTrustERC721 is TitleEscrowCloner, ERC721Mintable, IERC721Receiver {
+contract TradeTrustERC721 is ERC721, MinterRole, TitleEscrowCloner, IERC721Receiver {
   event TokenBurnt(uint256 indexed tokenId);
   event TokenReceived(address indexed operator, address indexed from, uint256 indexed tokenId, bytes data);
 
-  constructor(string memory name, string memory symbol) ERC721Mintable(name, symbol) {return;}
+  constructor(string memory name, string memory symbol) ERC721(name, symbol) {return;}
 
-  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721Mintable) returns (bool) {
+  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, MinterRole) returns (bool) {
     return
     interfaceId == type(ITitleEscrowCreator).interfaceId ||
     interfaceId == type(ITradeTrustERC721).interfaceId ||
-    ERC721Mintable.supportsInterface(interfaceId);
+    MinterRole.supportsInterface(interfaceId) ||
+    ERC721.supportsInterface(interfaceId);
   }
 
   function onERC721Received(

--- a/contracts/mocks/TradeTrustERC721Mock.sol
+++ b/contracts/mocks/TradeTrustERC721Mock.sol
@@ -14,7 +14,7 @@ contract TradeTrustERC721Mock is TradeTrustERC721 {
    * @param tokenId The token id to mint.
    * @return A boolean that indicates if the operation was successful.
    */
-  function mint(address to, uint256 tokenId) public onlyMinter returns (bool) {
+  function mintInternal(address to, uint256 tokenId) public onlyMinter returns (bool) {
     _mint(to, tokenId);
     return true;
   }
@@ -25,7 +25,7 @@ contract TradeTrustERC721Mock is TradeTrustERC721 {
    * @param tokenId The token id to mint.
    * @return A boolean that indicates if the operation was successful.
    */
-  function safeMint(address to, uint256 tokenId) public onlyMinter returns (bool) {
+  function safeMintInternal(address to, uint256 tokenId) public onlyMinter returns (bool) {
     _safeMint(to, tokenId);
     return true;
   }

--- a/contracts/mocks/TradeTrustERC721Mock.sol
+++ b/contracts/mocks/TradeTrustERC721Mock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../TradetrustERC721.sol";
+import { ERC721Mintable } from "../lib/ERC721.sol";
+
+contract TradeTrustERC721Mock is TradeTrustERC721 {
+
+  constructor(string memory name, string memory symbol) TradeTrustERC721(name, symbol) {}
+
+  /**
+ * @dev Function to mint tokens.
+   * @param to The address that will receive the minted token.
+   * @param tokenId The token id to mint.
+   * @return A boolean that indicates if the operation was successful.
+   */
+  function mint(address to, uint256 tokenId) public onlyMinter returns (bool) {
+    _mint(to, tokenId);
+    return true;
+  }
+
+  /**
+   * @dev Function to safely mint tokens.
+   * @param to The address that will receive the minted token.
+   * @param tokenId The token id to mint.
+   * @return A boolean that indicates if the operation was successful.
+   */
+  function safeMint(address to, uint256 tokenId) public onlyMinter returns (bool) {
+    _safeMint(to, tokenId);
+    return true;
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,9 @@
 import { providers } from "ethers";
 import {
   TitleEscrowCloneable__factory as TitleEscrowCloneableFactory,
-  TradeTrustERC721__factory as TradeTrustERC721Factory,
+  TradeTrustERC721Mock__factory as TradeTrustERC721MockFactory,
   TitleEscrowCloner__factory as TitleEscrowClonerFactory,
-  TradeTrustERC721,
+  TradeTrustERC721Mock,
   TitleEscrowCloner,
 } from "./contracts";
 
@@ -20,13 +20,13 @@ beforeAll(async () => {
 });
 
 describe("TitleEscrowClonerFactory", () => {
-  let tokenRegistry: TradeTrustERC721;
+  let tokenRegistry: TradeTrustERC721Mock;
   let titleEscrowFactory: TitleEscrowCloner;
 
   beforeEach(async () => {
     const factory = new TitleEscrowClonerFactory(signer1);
     titleEscrowFactory = await factory.deploy();
-    const tokenRegistryFactory = new TradeTrustERC721Factory(signer1);
+    const tokenRegistryFactory = new TradeTrustERC721MockFactory(signer1);
     tokenRegistry = await tokenRegistryFactory.deploy("MY_TOKEN_REGISTRY", "TKN");
   });
 
@@ -46,10 +46,10 @@ describe("TitleEscrowClonerFactory", () => {
 });
 
 describe("TitleEscrowCloneableFactory", () => {
-  let tokenRegistry: TradeTrustERC721;
+  let tokenRegistry: TradeTrustERC721Mock;
 
   beforeEach(async () => {
-    const tokenRegistryFactory = new TradeTrustERC721Factory(signer1);
+    const tokenRegistryFactory = new TradeTrustERC721MockFactory(signer1);
     tokenRegistry = await tokenRegistryFactory.deploy("MY_TOKEN_REGISTRY", "TKN");
   });
 
@@ -84,7 +84,7 @@ describe("TitleEscrowCloneableFactory", () => {
 
   it("should be able to write to TitleEscrow", async () => {
     const escrowInstance = await deployTitleEscrow();
-    await tokenRegistry["safeMint(address,uint256)"](escrowInstance.address, tokenId);
+    await tokenRegistry["safeMintInternal(address,uint256)"](escrowInstance.address, tokenId);
     await escrowInstance.approveNewOwner(account2);
     const target = await escrowInstance.approvedOwner();
     expect(target).toBe(account2);
@@ -93,7 +93,7 @@ describe("TitleEscrowCloneableFactory", () => {
 
 describe("TradeTrustErc721Factory", () => {
   const deployTradeTrustERC721 = async () => {
-    const factory = new TradeTrustERC721Factory(signer1);
+    const factory = new TradeTrustERC721MockFactory(signer1);
     const registryInstance = await factory.deploy("TOKEN_REGISTRY_NAME", "TKN");
     return registryInstance;
   };
@@ -105,13 +105,13 @@ describe("TradeTrustErc721Factory", () => {
   });
   it("should be able to connect to an existing TradeTrustERC721", async () => {
     const deployedInstance = await deployTradeTrustERC721();
-    const instance = await TradeTrustERC721Factory.connect(deployedInstance.address, signer1);
+    const instance = await TradeTrustERC721MockFactory.connect(deployedInstance.address, signer1);
     const sym = await instance.symbol();
     expect(sym).toBe("TKN");
   });
   it("should be able to write to TradeTrustERC721", async () => {
     const instance = await deployTradeTrustERC721();
-    await instance["safeMint(address,uint256)"](account1, tokenId);
+    await instance["safeMintInternal(address,uint256)"](account1, tokenId);
     const ownerOfToken = await instance.ownerOf(tokenId);
     expect(ownerOfToken).toBe(account1);
   });

--- a/test/TitleEscrowCloneable.js
+++ b/test/TitleEscrowCloneable.js
@@ -118,7 +118,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should update status upon receiving a ERC721 token", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
     ).wait();
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance.address);
     const owner = await ERC721Instance.ownerOf(SAMPLE_TOKEN_ID);
@@ -132,7 +132,7 @@ describe("TitleEscrowCloneable", async () => {
     const newERC721Instance = await ERC721Factory.connect(beneficiary1).deploy("foo", "bar");
 
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, beneficiary1.address, newERC721Instance.address);
-    const mintTx = ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID);
+    const mintTx = ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID);
 
     await expect(mintTx).to.be.revertedWith("TitleEscrow: Only tokens from predefined token registry can be accepted");
   });
@@ -143,7 +143,7 @@ describe("TitleEscrowCloneable", async () => {
     const escrowInstance2 = await makeTitleEscrow(beneficiary2.address, holder2.address);
 
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance1.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance1.address, SAMPLE_TOKEN_ID)
     ).wait();
 
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance1.address);
@@ -159,7 +159,7 @@ describe("TitleEscrowCloneable", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, beneficiary1.address);
 
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
     ).wait();
 
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance.address);
@@ -175,7 +175,7 @@ describe("TitleEscrowCloneable", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
 
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
     ).wait();
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance.address);
 
@@ -199,7 +199,7 @@ describe("TitleEscrowCloneable", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
 
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
     ).wait();
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance.address);
 
@@ -216,7 +216,7 @@ describe("TitleEscrowCloneable", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, beneficiary1.address);
 
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
     ).wait();
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance.address);
 
@@ -226,7 +226,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should not allow holder to transfer to new beneficiary without endorsement", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
     ).wait();
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance.address);
 
@@ -241,7 +241,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should not allow unauthorised party to execute any state change", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)
     ).wait();
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance.address);
 
@@ -264,7 +264,7 @@ describe("TitleEscrowCloneable", async () => {
     const escrowInstance2 = (await makeTitleEscrow(beneficiary2.address, holder2.address)).connect(beneficiary2);
 
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance1.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance1.address, SAMPLE_TOKEN_ID)
     ).wait();
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance1.address);
 
@@ -289,7 +289,7 @@ describe("TitleEscrowCloneable", async () => {
     const escrowInstance2 = (await makeTitleEscrow(beneficiary2.address, beneficiary2.address)).connect(beneficiary2);
 
     const mintTx = await (
-      await ERC721Instance["safeMint(address,uint256)"](escrowInstance1.address, SAMPLE_TOKEN_ID)
+      await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance1.address, SAMPLE_TOKEN_ID)
     ).wait();
     assertTransferLog(mintTx.events[0], ZERO_ADDRESS, escrowInstance1.address);
 
@@ -312,7 +312,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should be able to transfer to a new beneficiary and holder instantly", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, beneficiary1.address);
 
-    await (await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
+    await (await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
 
     const receipt = await (
       await escrowInstance.connect(beneficiary1).transferToNewEscrow(beneficiary2.address, holder2.address)
@@ -336,7 +336,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should allow current beneficiary to appoint new beneficiary and holder as the transfer target", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
 
-    await (await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
+    await (await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
 
     const prevApprovedBeneficiary = await escrowInstance.approvedBeneficiary();
     const prevApprovedHolder = await escrowInstance.approvedHolder();
@@ -369,7 +369,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should not allow user to appoint new beneficiary and holder when user is not the beneficiary", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
 
-    await (await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
+    await (await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
 
     const attemptToAppoint = escrowInstance
       .connect(carrier1)
@@ -383,7 +383,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should allow holder to execute transferToNewEscrow when new beneficiary and holder has been appointed by beneficiary", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
 
-    await (await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
+    await (await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
 
     await (
       await escrowInstance.connect(beneficiary1).approveNewTransferTargets(beneficiary2.address, holder2.address)
@@ -405,7 +405,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should not allow holder to execute transferToNewEscrow when new beneficiary and holder has not been appointed", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
 
-    await (await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
+    await (await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
 
     const attemptToTransfer = escrowInstance
       .connect(holder1)
@@ -417,7 +417,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should not allow anyone else (esp beneficiary) to execute transferToNewEscrow when new beneficiary and holder has been appointed", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
 
-    await (await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
+    await (await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
 
     const attemptToTransferByBeneficiay = escrowInstance
       .connect(beneficiary1)
@@ -435,7 +435,7 @@ describe("TitleEscrowCloneable", async () => {
   it("should not allow holder to execute transferToNewEscrow to other targets not appointed by beneficiary", async () => {
     const escrowInstance = await makeTitleEscrow(beneficiary1.address, holder1.address);
 
-    await (await ERC721Instance["safeMint(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
+    await (await ERC721Instance["safeMintInternal(address,uint256)"](escrowInstance.address, SAMPLE_TOKEN_ID)).wait();
 
     await (
       await escrowInstance.connect(beneficiary1).approveNewTransferTargets(beneficiary2.address, holder2.address)

--- a/test/TitleEscrowCloneable.js
+++ b/test/TitleEscrowCloneable.js
@@ -15,7 +15,7 @@ describe("TitleEscrowCloneable", async () => {
   before("Initialising contract factories and accounts for TitleEscrow tests", async () => {
     [carrier1, beneficiary1, beneficiary2, holder1, holder2] = await ethers.getSigners();
     TitleEscrowCloneableFactory = await ethers.getContractFactory("TitleEscrowCloneableMock");
-    ERC721Factory = await ethers.getContractFactory("TradeTrustERC721");
+    ERC721Factory = await ethers.getContractFactory("TradeTrustERC721Mock");
     TitleEscrowClonerFactory = await ethers.getContractFactory("TitleEscrowClonerMock");
 
     TitleEscrowCloner = await TitleEscrowClonerFactory.connect(carrier1).deploy();

--- a/test/TitleEscrowCloner.js
+++ b/test/TitleEscrowCloner.js
@@ -76,7 +76,7 @@ describe("TitleEscrowCloner", async () => {
     ).wait();
     const { escrowAddress } = events[1].args;
 
-    await ERC721Instance["safeMint(address,uint256)"](escrowAddress, SAMPLE_TOKEN_ID);
+    await ERC721Instance["safeMintInternal(address,uint256)"](escrowAddress, SAMPLE_TOKEN_ID);
 
     const escrowInstance = await TitleEscrowCloneableFactory.attach(escrowAddress);
     const receipt = await (

--- a/test/TitleEscrowCloner.js
+++ b/test/TitleEscrowCloner.js
@@ -20,7 +20,7 @@ describe("TitleEscrowCloner", async () => {
     [carrier1, beneficiary1, beneficiary2, holder2] = await ethers.getSigners();
     TitleEscrowClonerFactory = await ethers.getContractFactory("TitleEscrowClonerMock");
     TitleEscrowCloneableFactory = await ethers.getContractFactory("TitleEscrowCloneableMock");
-    ERC721 = await ethers.getContractFactory("TradeTrustERC721");
+    ERC721 = await ethers.getContractFactory("TradeTrustERC721Mock");
   });
 
   let ERC721Address = "";

--- a/test/TradeTrustERC721.js
+++ b/test/TradeTrustERC721.js
@@ -28,7 +28,7 @@ describe("TradeTrustErc721", async () => {
   before("Initialising contract factories and accounts for TradeTrustErc721 tests", async () => {
     [carrier1, owner1, owner2, nonMinter, holder1] = await ethers.getSigners();
     TitleEscrow = await ethers.getContractFactory("TitleEscrowCloneableMock");
-    Erc721 = await ethers.getContractFactory("TradeTrustERC721");
+    Erc721 = await ethers.getContractFactory("TradeTrustERC721Mock");
   });
 
   const merkleRoot = "0x624d0d7ae6f44d41d368d8280856dbaac6aa29fb3b35f45b80a7c1c90032eeb3";

--- a/test/TradeTrustERC721.js
+++ b/test/TradeTrustERC721.js
@@ -53,14 +53,14 @@ describe("TradeTrustErc721", async () => {
 
   it("should work without a wallet for read operations", async () => {
     const tokenRegistryInstanceWithShippingLine = await Erc721.connect(carrier1).deploy("foo", "bar");
-    await tokenRegistryInstanceWithShippingLine.mint(owner1.address, merkleRoot);
+    await tokenRegistryInstanceWithShippingLine.mintInternal(owner1.address, merkleRoot);
     const currentOwner = await tokenRegistryInstanceWithShippingLine.ownerOf(merkleRoot);
     expect(currentOwner).to.deep.equal(owner1.address);
   });
 
   it("should not burn tokens that it receives", async () => {
     const tokenRegistryInstanceWithShippingLine = await Erc721.connect(carrier1).deploy("foo", "bar");
-    await tokenRegistryInstanceWithShippingLine.mint(owner1.address, merkleRoot);
+    await tokenRegistryInstanceWithShippingLine.mintInternal(owner1.address, merkleRoot);
     const currentOwner = await tokenRegistryInstanceWithShippingLine.ownerOf(merkleRoot);
     expect(currentOwner).to.deep.equal(owner1.address);
 
@@ -77,14 +77,14 @@ describe("TradeTrustErc721", async () => {
 
   it("should be able to mint", async () => {
     const tokenRegistryInstance = await Erc721.connect(carrier1).deploy("foo", "bar");
-    await tokenRegistryInstance.mint(owner1.address, merkleRoot);
+    await tokenRegistryInstance.mintInternal(owner1.address, merkleRoot);
     const currentOwner = await tokenRegistryInstance.ownerOf(merkleRoot);
     expect(currentOwner).to.deep.equal(owner1.address);
   });
 
   it("should be able to transfer", async () => {
     const tokenRegistryInstanceWithShippingLineWallet = await Erc721.connect(carrier1).deploy("foo", "bar");
-    await tokenRegistryInstanceWithShippingLineWallet.mint(owner1.address, merkleRoot);
+    await tokenRegistryInstanceWithShippingLineWallet.mintInternal(owner1.address, merkleRoot);
     const currentOwner = await tokenRegistryInstanceWithShippingLineWallet.ownerOf(merkleRoot);
     expect(currentOwner).to.deep.equal(owner1.address);
 
@@ -97,7 +97,7 @@ describe("TradeTrustErc721", async () => {
 
   it("non-owner should not be able to initiate a transfer", async () => {
     const tokenRegistryInstanceWithShippingLine = await Erc721.connect(carrier1).deploy("foo", "bar");
-    await tokenRegistryInstanceWithShippingLine.mint(owner1.address, merkleRoot);
+    await tokenRegistryInstanceWithShippingLine.mintInternal(owner1.address, merkleRoot);
     const currentOwner = await tokenRegistryInstanceWithShippingLine.ownerOf(merkleRoot);
     expect(currentOwner).to.deep.equal(owner1.address);
 
@@ -113,7 +113,7 @@ describe("TradeTrustErc721", async () => {
     const tokenRegistryInstance = await Erc721.connect(carrier1).deploy("foo", "bar");
     const tokenRegistryInstanceAddress = tokenRegistryInstance.address;
     const mintTx = await (
-      await tokenRegistryInstance["safeMint(address,uint256)"](tokenRegistryInstanceAddress, merkleRoot)
+      await tokenRegistryInstance["safeMintInternal(address,uint256)"](tokenRegistryInstanceAddress, merkleRoot)
     ).wait();
     const receivedTokenLog = mintTx.events.find((log) => log.event === "TokenReceived");
     assertTokenReceivedLog(receivedTokenLog, carrier1.address, ZERO_ADDRESS, merkleRoot, null);
@@ -127,7 +127,10 @@ describe("TradeTrustErc721", async () => {
       // Starting test after the point of surrendering ERC721 Token
       tokenRegistryInstanceWithShippingLineWallet = await Erc721.connect(carrier1).deploy("foo", "bar");
       tokenRegistryAddress = tokenRegistryInstanceWithShippingLineWallet.address;
-      await tokenRegistryInstanceWithShippingLineWallet["safeMint(address,uint256)"](tokenRegistryAddress, merkleRoot);
+      await tokenRegistryInstanceWithShippingLineWallet["safeMintInternal(address,uint256)"](
+        tokenRegistryAddress,
+        merkleRoot
+      );
     });
 
     it("should be able to destroy token", async () => {
@@ -146,7 +149,10 @@ describe("TradeTrustErc721", async () => {
     });
 
     it("token cannot be destroyed if not owned by registry", async () => {
-      await tokenRegistryInstanceWithShippingLineWallet["safeMint(address,uint256)"](owner1.address, merkleRoot1);
+      await tokenRegistryInstanceWithShippingLineWallet["safeMintInternal(address,uint256)"](
+        owner1.address,
+        merkleRoot1
+      );
       const attemptDestroyToken = tokenRegistryInstanceWithShippingLineWallet.destroyToken(merkleRoot1);
       await expect(attemptDestroyToken).to.be.revertedWith("Token has not been surrendered");
     });
@@ -195,7 +201,10 @@ describe("TradeTrustErc721", async () => {
       });
 
       it("should not allow a minter to restore a title not owned by registry", async () => {
-        await tokenRegistryInstanceWithShippingLineWallet["safeMint(address,uint256)"](owner1.address, merkleRoot1);
+        await tokenRegistryInstanceWithShippingLineWallet["safeMintInternal(address,uint256)"](
+          owner1.address,
+          merkleRoot1
+        );
 
         const tx = tokenRegistryInstanceWithShippingLineWallet.restoreTitle(
           beneficiary.address,

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -27,7 +27,10 @@ describe("TradeTrustErc721", async () => {
       const escrowInstance = TitleEscrow.connect(beneficiary1).attach(event.args.escrowAddress);
 
       const escrowInstanceAddress = escrowInstance.address;
-      await tokenRegistryInstanceWithShippingLineWallet["safeMint(address,uint256)"](escrowInstanceAddress, merkleRoot);
+      await tokenRegistryInstanceWithShippingLineWallet["safeMintInternal(address,uint256)"](
+        escrowInstanceAddress,
+        merkleRoot
+      );
       const currentOwner = await tokenRegistryInstanceWithShippingLineWallet.ownerOf(merkleRoot);
       expect(currentOwner).to.deep.equal(escrowInstanceAddress);
       await escrowInstance.surrender();

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -2,7 +2,7 @@ const { expect } = require("chai").use(require("chai-as-promised"));
 
 describe("TradeTrustErc721", async () => {
   const accounts = await ethers.getSigners();
-  const Erc721 = await ethers.getContractFactory("TradeTrustERC721");
+  const Erc721 = await ethers.getContractFactory("TradeTrustERC721Mock");
   const TitleEscrow = await ethers.getContractFactory("TitleEscrowCloneableMock");
   const shippingLine = accounts[0];
   const beneficiary1 = accounts[1];


### PR DESCRIPTION
## Summary
Remove `mint` function. Minting will use `mintTitle` instead so as to restrict minting to EOA directly.

## Changes
* Remove inherit from ERC721 mintable
* Update tests that rely on `mint` for testing to use a mock version of it

## Issues
* https://www.pivotaltracker.com/story/show/181456297

## Releases
Channels: latest
