### PR TITLE
refactor: clean up

### DIFF
--- a/contracts/TradeTrustERC721.sol
+++ b/contracts/TradeTrustERC721.sol
@@ -11,7 +11,7 @@ import "./interfaces/ITitleEscrow.sol";
 import "./interfaces/ITradeTrustERC721.sol";
 import "./access/MinterRole.sol";
 
-contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, IERC721Receiver, ERC721 {
+contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, ITradeTrustERC721, ERC721 {
   using Address for address;
 
   event TokenBurnt(uint256 indexed tokenId);
@@ -27,7 +27,7 @@ contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, IERC721Receiver, ERC
     return;
   }
 
-  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, MinterRole) returns (bool) {
+  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, IERC165, MinterRole) returns (bool) {
     return
       interfaceId == type(ITitleEscrowCreator).interfaceId ||
       interfaceId == type(ITradeTrustERC721).interfaceId ||
@@ -58,7 +58,7 @@ contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, IERC721Receiver, ERC
    *
    * @param tokenId Token ID to be burnt
    */
-  function destroyToken(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function destroyToken(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) override {
     emit TokenBurnt(tokenId);
 
     // Burning token to 0xdead instead to show a differentiate state as address(0) is used for unminted tokens
@@ -72,13 +72,13 @@ contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, IERC721Receiver, ERC
     address beneficiary,
     address holder,
     uint256 tokenId
-  ) public virtual onlyMinter returns (address) {
+  ) public virtual onlyMinter override returns (address) {
     require(!_exists(tokenId), "TokenRegistry: Token already exists");
 
     return _mintTitle(beneficiary, holder, tokenId);
   }
 
-  function restoreTitle(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) returns (address) {
+  function restoreTitle(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) override returns (address) {
     address previousOwner = _surrenderedOwners[tokenId];
     require(_exists(tokenId), "TokenRegistry: Token does not exist");
     require(isSurrendered(tokenId), "TokenRegistry: Token is not surrendered");

--- a/contracts/TradeTrustERC721.sol
+++ b/contracts/TradeTrustERC721.sol
@@ -158,15 +158,6 @@ contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, ITradeTrustERC721, E
     address to,
     uint256 tokenId
   ) internal {
-    _registrySafeTransformFrom(from, to, tokenId, "");
-  }
-
-  function _registrySafeTransformFrom(
-    address from,
-    address to,
-    uint256 tokenId,
-    bytes memory data
-  ) internal {
-    this.safeTransferFrom(from, to, tokenId, data);
+    this.safeTransferFrom(from, to, tokenId, "");
   }
 }

--- a/contracts/TradeTrustERC721.sol
+++ b/contracts/TradeTrustERC721.sol
@@ -11,7 +11,7 @@ import "./interfaces/ITitleEscrow.sol";
 import "./interfaces/ITradeTrustERC721.sol";
 import "./access/MinterRole.sol";
 
-contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, ITradeTrustERC721, ERC721 {
+contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, IERC721Receiver, ERC721 {
   using Address for address;
 
   event TokenBurnt(uint256 indexed tokenId);
@@ -27,7 +27,7 @@ contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, ITradeTrustERC721, E
     return;
   }
 
-  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, IERC165, MinterRole) returns (bool) {
+  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, MinterRole) returns (bool) {
     return
       interfaceId == type(ITitleEscrowCreator).interfaceId ||
       interfaceId == type(ITradeTrustERC721).interfaceId ||
@@ -58,7 +58,7 @@ contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, ITradeTrustERC721, E
    *
    * @param tokenId Token ID to be burnt
    */
-  function destroyToken(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) override {
+  function destroyToken(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) {
     emit TokenBurnt(tokenId);
 
     // Burning token to 0xdead instead to show a differentiate state as address(0) is used for unminted tokens
@@ -72,13 +72,13 @@ contract TradeTrustERC721 is MinterRole, TitleEscrowCloner, ITradeTrustERC721, E
     address beneficiary,
     address holder,
     uint256 tokenId
-  ) public virtual onlyMinter override returns (address) {
+  ) public virtual onlyMinter returns (address) {
     require(!_exists(tokenId), "TokenRegistry: Token already exists");
 
     return _mintTitle(beneficiary, holder, tokenId);
   }
 
-  function restoreTitle(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) override returns (address) {
+  function restoreTitle(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) returns (address) {
     address previousOwner = _surrenderedOwners[tokenId];
     require(_exists(tokenId), "TokenRegistry: Token does not exist");
     require(isSurrendered(tokenId), "TokenRegistry: Token is not surrendered");

--- a/contracts/access/IMinterRole.sol
+++ b/contracts/access/IMinterRole.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+interface IMinterRole {
+  function isMinter(address account) external view returns (bool);
+
+  function addMinter(address account) external;
+
+  function renounceMinter() external;
+}

--- a/contracts/access/MinterRole.sol
+++ b/contracts/access/MinterRole.sol
@@ -1,17 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./IMinterRole.sol";
 
-interface IMinterRole {
-  function isMinter(address account) external view returns (bool);
-
-  function addMinter(address account) external;
-
-  function renounceMinter() external;
-}
-
-abstract contract MinterRole is IMinterRole, AccessControlEnumerable {
+abstract contract MinterRole is IMinterRole, AccessControl {
   bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
   event MinterAdded(address indexed account);
@@ -22,8 +15,8 @@ abstract contract MinterRole is IMinterRole, AccessControlEnumerable {
     _setupRole(MINTER_ROLE, _msgSender());
   }
 
-  function supportsInterface(bytes4 interfaceId) public view virtual override(AccessControlEnumerable) returns (bool) {
-    return interfaceId == type(IMinterRole).interfaceId || AccessControlEnumerable.supportsInterface(interfaceId);
+  function supportsInterface(bytes4 interfaceId) public view virtual override(AccessControl) returns (bool) {
+    return interfaceId == type(IMinterRole).interfaceId || AccessControl.supportsInterface(interfaceId);
   }
 
   modifier onlyMinter() {

--- a/contracts/access/MinterRole.sol
+++ b/contracts/access/MinterRole.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 
 interface IMinterRole {
@@ -12,7 +11,7 @@ interface IMinterRole {
   function renounceMinter() external;
 }
 
-abstract contract MinterRole is Context, IMinterRole, AccessControlEnumerable {
+abstract contract MinterRole is IMinterRole, AccessControlEnumerable {
   bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
   event MinterAdded(address indexed account);


### PR DESCRIPTION
## Summary
A general refactoring and clean-up of the code after a milestone.

## Changes
* Remove overloaded `_registrySafeTransferFrom` function 
* Clean up minter role contract
* Clean up interfaces

## Issues
* https://www.pivotaltracker.com/story/show/181658031

## Releases
Channels: beta
