### PR TITLE
feat: signable title escrow

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "printWidth": 120,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "bracketSpacing": true
 }

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,6 +1,6 @@
 module.exports = {
   skipFiles: [
-    'lib',
+    'lib/external',
     'mocks'
   ],
   istanbulReporter: ['lcov', 'text', 'text-summary', 'html']

--- a/contracts/TitleEscrowSignable.sol
+++ b/contracts/TitleEscrowSignable.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "./TitleEscrow.sol";
+import "./utils/SigHelper.sol";
+
+contract TitleEscrowSignable is SigHelper, TitleEscrow {
+  string public constant name = "TradeTrust Title Escrow";
+
+  // BeneficiaryTransfer(address beneficiary,address holder,address nominee,address registry,uint256 tokenId,uint256 deadline,uint256 nonce)
+  bytes32 public constant BENEFICIARY_TRANSFER_TYPEHASH =
+    0xdc8ea80c045a9b675c73cb328c225cc3f099d01bd9b7820947ac10cba8661cf1;
+
+  struct BeneficiaryTransferEndorsement {
+    // Transfer proposer
+    address beneficiary;
+    // Endorser
+    address holder;
+    // Endorsed nominee
+    address nominee;
+    address registry;
+    uint256 tokenId;
+    uint256 deadline;
+    uint256 nonce;
+  }
+
+  event CancelBeneficiaryTransferEndorsement(bytes32 indexed hash, address indexed endorser, uint256 indexed tokenId);
+
+  function initialize(address _registry, uint256 _tokenId) public virtual override initializer {
+    __TitleEscrowSignable_init(_registry, _tokenId);
+  }
+
+  function __TitleEscrowSignable_init(address _registry, uint256 _tokenId) internal virtual onlyInitializing {
+    super.__TitleEscrow_init(_registry, _tokenId);
+    __SigHelper_init(name, "1");
+  }
+
+  function transferBeneficiaryWithSig(BeneficiaryTransferEndorsement memory endorsement, Sig memory sig)
+    public
+    virtual
+    whenNotPaused
+    whenActive
+    onlyBeneficiary
+    whenHoldingToken
+  {
+    require(endorsement.deadline >= block.timestamp, "TE: Expired");
+    require(
+      endorsement.nominee != address(0) &&
+        endorsement.nominee != beneficiary &&
+        endorsement.holder == holder &&
+        endorsement.tokenId == tokenId &&
+        endorsement.registry == registry,
+      "TE: Invalid endorsement"
+    );
+
+    if (beneficiaryNominee != address(0)) {
+      require(endorsement.nominee == beneficiaryNominee, "TE: Nominee mismatch");
+    }
+
+    require(endorsement.beneficiary == beneficiary, "TE: Beneficiary mismatch");
+    require(_validateSig(_hash(endorsement), holder, sig), "TE: Invalid signature");
+
+    ++nonces[holder];
+    _setBeneficiary(endorsement.nominee);
+  }
+
+  function cancelBeneficiaryTransfer(BeneficiaryTransferEndorsement memory endorsement)
+    public
+    virtual
+    whenNotPaused
+    whenActive
+  {
+    require(msg.sender == endorsement.holder, "TE: Caller not endorser");
+
+    bytes32 hash = _hash(endorsement);
+    _cancelHash(hash);
+
+    emit CancelBeneficiaryTransferEndorsement(hash, endorsement.holder, endorsement.tokenId);
+  }
+
+  function _hash(BeneficiaryTransferEndorsement memory endorsement) internal view returns (bytes32) {
+    return
+      keccak256(
+        abi.encode(
+          BENEFICIARY_TRANSFER_TYPEHASH,
+          endorsement.beneficiary,
+          endorsement.holder,
+          endorsement.nominee,
+          endorsement.registry,
+          endorsement.tokenId,
+          endorsement.deadline,
+          nonces[endorsement.holder]
+        )
+      );
+  }
+
+  function _setHolder(address newHolder) internal virtual override {
+    ++nonces[holder];
+    super._setHolder(newHolder);
+  }
+}

--- a/contracts/TitleEscrowSignable.sol
+++ b/contracts/TitleEscrowSignable.sol
@@ -3,28 +3,17 @@ pragma solidity ^0.8.0;
 
 import "./TitleEscrow.sol";
 import "./utils/SigHelper.sol";
+import { BeneficiaryTransferEndorsement } from "./lib/TitleEscrowStructs.sol";
+import "./interfaces/ITitleEscrowSignable.sol";
 
-contract TitleEscrowSignable is SigHelper, TitleEscrow {
+/// @notice This Title Escrow allows the holder to perform an off-chain endorsement of beneficiary transfers
+/// @custom:experimental Note that this is currently an experimental feature. See readme for usage details.
+contract TitleEscrowSignable is SigHelper, TitleEscrow, ITitleEscrowSignable {
   string public constant name = "TradeTrust Title Escrow";
 
   // BeneficiaryTransfer(address beneficiary,address holder,address nominee,address registry,uint256 tokenId,uint256 deadline,uint256 nonce)
   bytes32 public constant BENEFICIARY_TRANSFER_TYPEHASH =
     0xdc8ea80c045a9b675c73cb328c225cc3f099d01bd9b7820947ac10cba8661cf1;
-
-  struct BeneficiaryTransferEndorsement {
-    // Transfer proposer
-    address beneficiary;
-    // Endorser
-    address holder;
-    // Endorsed nominee
-    address nominee;
-    address registry;
-    uint256 tokenId;
-    uint256 deadline;
-    uint256 nonce;
-  }
-
-  event CancelBeneficiaryTransferEndorsement(bytes32 indexed hash, address indexed endorser, uint256 indexed tokenId);
 
   function initialize(address _registry, uint256 _tokenId) public virtual override initializer {
     __TitleEscrowSignable_init(_registry, _tokenId);
@@ -33,6 +22,10 @@ contract TitleEscrowSignable is SigHelper, TitleEscrow {
   function __TitleEscrowSignable_init(address _registry, uint256 _tokenId) internal virtual onlyInitializing {
     super.__TitleEscrow_init(_registry, _tokenId);
     __SigHelper_init(name, "1");
+  }
+
+  function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    return super.supportsInterface(interfaceId) || interfaceId == type(ITitleEscrowSignable).interfaceId;
   }
 
   function transferBeneficiaryWithSig(BeneficiaryTransferEndorsement memory endorsement, Sig memory sig)

--- a/contracts/interfaces/ITitleEscrowSignable.sol
+++ b/contracts/interfaces/ITitleEscrowSignable.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "../utils/SigHelper.sol";
+import "./ITitleEscrow.sol";
+import { BeneficiaryTransferEndorsement } from "../lib/TitleEscrowStructs.sol";
+
+interface ITitleEscrowSignable is ITitleEscrow {
+  event CancelBeneficiaryTransferEndorsement(bytes32 indexed hash, address indexed endorser, uint256 indexed tokenId);
+
+  function transferBeneficiaryWithSig(BeneficiaryTransferEndorsement memory endorsement, SigHelper.Sig memory sig)
+    external;
+
+  function cancelBeneficiaryTransfer(BeneficiaryTransferEndorsement memory endorsement) external;
+}

--- a/contracts/lib/TitleEscrowStructs.sol
+++ b/contracts/lib/TitleEscrowStructs.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+  @dev BeneficiaryTransferEndorsement represents the endorsement details.
+       The beneficiary is the transfer proposer, holder is the endorser, nominee is the endorsed nominee, registry is
+       the token registry, tokenId is the token id, deadline is the expiry in seconds and nonce is the holder's nonce.
+*/
+struct BeneficiaryTransferEndorsement {
+  address beneficiary;
+  address holder;
+  address nominee;
+  address registry;
+  uint256 tokenId;
+  uint256 deadline;
+  uint256 nonce;
+}

--- a/contracts/mocks/SigHelperMock.sol
+++ b/contracts/mocks/SigHelperMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../utils/SigHelper.sol";
+
+contract SigHelperMock is SigHelper {
+  constructor(string memory name) {
+    __SigHelper_init(name, "1");
+  }
+
+  function __SigHelper_initInternal(string memory name, string memory version) public {
+    super.__SigHelper_init(name, version);
+  }
+
+  function validateSigInternal(
+    bytes32 hash,
+    address signer,
+    Sig memory sig
+  ) public view returns (bool) {
+    return super._validateSig(hash, signer, sig);
+  }
+
+  function cancelHashInternal(bytes32 hash) public {
+    super._cancelHash(hash);
+  }
+}

--- a/contracts/utils/SigHelper.sol
+++ b/contracts/utils/SigHelper.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
+
+abstract contract SigHelper {
+  using ECDSAUpgradeable for bytes32;
+
+  bytes32 public DOMAIN_SEPARATOR;
+  mapping(address => uint256) public nonces;
+  mapping(bytes32 => bool) public cancelled;
+
+  struct Sig {
+    bytes32 r;
+    bytes32 s;
+    uint8 v;
+  }
+
+  function __SigHelper_init(string memory name, string memory version) internal {
+    DOMAIN_SEPARATOR = keccak256(
+      abi.encode(
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+        keccak256(bytes(name)),
+        keccak256(bytes(version)),
+        block.chainid,
+        address(this)
+      )
+    );
+  }
+
+  function _validateSig(
+    bytes32 hash,
+    address signer,
+    Sig memory sig
+  ) internal view virtual returns (bool) {
+    require(!cancelled[hash], "Cancelled");
+    bytes32 digest = DOMAIN_SEPARATOR.toTypedDataHash(hash);
+    address rSigner = digest.recover(abi.encodePacked(sig.r, sig.s, sig.v));
+    return rSigner != address(0) && rSigner == signer;
+  }
+
+  function _cancelHash(bytes32 hash) internal virtual {
+    require(!cancelled[hash], "Cancelled");
+    cancelled[hash] = true;
+  }
+}

--- a/src/constants/contract-interface-id.ts
+++ b/src/constants/contract-interface-id.ts
@@ -1,9 +1,10 @@
-import { computeInterfaceId } from "../utils/compute-interface-id";
+import { computeInterfaceId } from "../utils";
 import { contractInterfaces } from "./contract-interfaces";
 
 export const contractInterfaceId = {
   TradeTrustERC721: computeInterfaceId(contractInterfaces.TradeTrustERC721),
   TitleEscrow: computeInterfaceId(contractInterfaces.TitleEscrow),
+  TitleEscrowSignable: computeInterfaceId(contractInterfaces.TitleEscrowSignable),
   TitleEscrowFactory: computeInterfaceId(contractInterfaces.TitleEscrowFactory),
   AccessControl: computeInterfaceId(contractInterfaces.AccessControl),
   ERC721: computeInterfaceId(contractInterfaces.ERC721),

--- a/src/constants/contract-interfaces.ts
+++ b/src/constants/contract-interfaces.ts
@@ -21,6 +21,10 @@ export const contractInterfaces = {
     "surrender()",
     "shred()",
   ],
+  TitleEscrowSignable: [
+    "transferBeneficiaryWithSig((address,address,address,address,uint256,uint256,uint256),(bytes32,bytes32,uint8))",
+    "cancelBeneficiaryTransfer((address,address,address,address,uint256,uint256,uint256))",
+  ],
   TitleEscrowFactory: ["create(address,address,uint256)", "getAddress(address,uint256)"],
   AccessControl: [
     "hasRole(bytes32,address)",

--- a/test/SigHelper.test.ts
+++ b/test/SigHelper.test.ts
@@ -1,0 +1,145 @@
+/* eslint-disable no-underscore-dangle */
+import { ethers } from "hardhat";
+import faker from "faker";
+import { SigHelperMock } from "@tradetrust/contracts";
+import { Signature } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect, assert } from ".";
+import { getTestUsers, TestUsers } from "./helpers";
+
+describe("SigHelper", async () => {
+  let users: TestUsers;
+  let sender: SignerWithAddress;
+  let deployer: SignerWithAddress;
+
+  let sigHelperMock: SigHelperMock;
+
+  const domainName = "Test Name";
+  let domain: Record<string, any>;
+
+  beforeEach(async () => {
+    users = await getTestUsers();
+    sender = users.carrier;
+    [deployer] = users.others;
+
+    sigHelperMock = (await (await ethers.getContractFactory("SigHelperMock"))
+      .connect(deployer)
+      .deploy(domainName)) as SigHelperMock;
+    sigHelperMock = sigHelperMock.connect(sender);
+
+    const chainId = await sender.getChainId();
+    domain = {
+      name: domainName,
+      version: "1",
+      chainId,
+      verifyingContract: sigHelperMock.address,
+    };
+  });
+
+  describe("Initialisation", () => {
+    it("should initialise the domain separator correctly", async () => {
+      const hashDomain = ethers.utils._TypedDataEncoder.hashDomain(domain);
+      await sigHelperMock.__SigHelper_initInternal(domainName, "1");
+
+      const res = await sigHelperMock.DOMAIN_SEPARATOR();
+
+      expect(res).to.equal(hashDomain);
+    });
+  });
+
+  describe("Cancellation", () => {
+    let fakeHash: string;
+
+    beforeEach(async () => {
+      fakeHash = ethers.utils.keccak256(ethers.utils.randomBytes(32));
+    });
+
+    it("should cancel successfully", async () => {
+      const initStatus = await sigHelperMock.cancelled(fakeHash);
+      assert(!initStatus, "Initial status should be false");
+
+      await sigHelperMock.cancelHashInternal(fakeHash);
+
+      const status = await sigHelperMock.cancelled(fakeHash);
+
+      expect(status).to.be.true;
+    });
+
+    it("should not cancel an already cancelled hash", async () => {
+      await sigHelperMock.cancelHashInternal(fakeHash);
+      const initStatus = await sigHelperMock.cancelled(fakeHash);
+      assert(initStatus, "Initial status should be true");
+
+      const tx = sigHelperMock.cancelHashInternal(fakeHash);
+
+      await expect(tx).to.be.rejectedWith(/cancelled/i);
+    });
+  });
+
+  describe("Validation", () => {
+    let hashStruct: string;
+    let sigHash: string;
+    let sig: Signature;
+    let fakeData: {
+      types: Record<string, { name: string; type: string }[]>;
+      domain: typeof domain;
+      message: Record<string, any>;
+    };
+
+    beforeEach(async () => {
+      fakeData = {
+        types: {
+          Endorsement: [
+            { name: "beneficiary", type: "address" },
+            { name: "deadline", type: "uint256" },
+          ],
+        },
+        domain,
+        message: {
+          beneficiary: faker.finance.ethereumAddress(),
+          deadline: Date.now(),
+        },
+      };
+
+      hashStruct = ethers.utils.keccak256(
+        ethers.utils.defaultAbiCoder.encode(
+          ["bytes32", "address", "uint256"],
+          [
+            ethers.utils.id("Endorsement(address beneficiary,uint256 deadline)"),
+            fakeData.message.beneficiary,
+            fakeData.message.deadline,
+          ]
+        )
+      );
+
+      sigHash = await sender._signTypedData(fakeData.domain, fakeData.types, fakeData.message);
+      sig = ethers.utils.splitSignature(sigHash);
+    });
+
+    it("should return true for a valid signature", async () => {
+      const res = await sigHelperMock.validateSigInternal(hashStruct, sender.address, sig);
+
+      expect(res).to.be.true;
+    });
+
+    it("should return false for an invalid signature", async () => {
+      sigHash = await sender._signTypedData(fakeData.domain, fakeData.types, {
+        beneficiary: faker.finance.ethereumAddress(),
+        deadline: Date.now(),
+      });
+      sig = ethers.utils.splitSignature(sigHash);
+
+      const res = await sigHelperMock.validateSigInternal(hashStruct, sender.address, sig);
+
+      expect(res).to.be.false;
+    });
+
+    it("should return false if hash has been cancelled", async () => {
+      await sigHelperMock.cancelHashInternal(hashStruct);
+
+      const tx = sigHelperMock.validateSigInternal(hashStruct, sender.address, sig);
+
+      await expect(tx).to.be.rejectedWith("Cancelled");
+    });
+  });
+});

--- a/test/TitleEscrowSignable.test.ts
+++ b/test/TitleEscrowSignable.test.ts
@@ -1,0 +1,469 @@
+/* eslint-disable no-underscore-dangle */
+import { ethers, waffle } from "hardhat";
+import faker from "faker";
+import { TitleEscrowSignable, TradeTrustERC721 } from "@tradetrust/contracts";
+import { Signature } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { FakeContract, smock } from "@defi-wonderland/smock";
+import { expect, assert } from ".";
+import { getTestUsers, TestUsers } from "./helpers";
+import { deployImplProxy } from "./fixtures/deploy-impl-proxy.fixture";
+
+const { loadFixture } = waffle;
+
+type BeneficiaryTransferData = {
+  beneficiary: string;
+  holder: string;
+  nominee: string;
+  registry: string;
+  tokenId: string;
+  deadline: number;
+  nonce: number;
+};
+
+describe("TitleEscrowSignable", async () => {
+  let users: TestUsers;
+  let deployer: SignerWithAddress;
+
+  let implContract: TitleEscrowSignable;
+  let titleEscrowContract: TitleEscrowSignable;
+
+  const domainName = "TradeTrust Title Escrow";
+  let domain: Record<string, any>;
+
+  // eslint-disable-next-line no-undef
+  before(async () => {
+    users = await getTestUsers();
+    deployer = users.carrier;
+  });
+
+  beforeEach(async () => {
+    implContract = await loadFixture(async () => {
+      return (await (await ethers.getContractFactory("TitleEscrowSignable"))
+        .connect(deployer)
+        .deploy()) as TitleEscrowSignable;
+    });
+    titleEscrowContract = await loadFixture(
+      deployImplProxy<TitleEscrowSignable>({
+        implementation: implContract,
+        deployer,
+      })
+    );
+
+    const chainId = await deployer.getChainId();
+    domain = {
+      name: domainName,
+      version: "1",
+      chainId,
+      verifyingContract: titleEscrowContract.address,
+    };
+  });
+
+  describe("Setup", () => {
+    it("should have correct name", async () => {
+      const res = await titleEscrowContract.name();
+
+      expect(res).to.equal(domainName);
+    });
+
+    it("should have correct beneficiary transfer type hash", async () => {
+      const typeHash = ethers.utils.id(
+        "BeneficiaryTransfer(address beneficiary,address holder,address nominee,address registry,uint256 tokenId,uint256 deadline,uint256 nonce)"
+      );
+
+      const res = await titleEscrowContract.BENEFICIARY_TRANSFER_TYPEHASH();
+
+      expect(res).to.equal(typeHash);
+    });
+  });
+
+  describe("Initialisation", () => {
+    let fakeRegistryAddress: string;
+    let fakeTokenId: string;
+
+    beforeEach(async () => {
+      fakeRegistryAddress = ethers.utils.getAddress(faker.finance.ethereumAddress());
+      fakeTokenId = faker.datatype.hexaDecimal(64);
+    });
+
+    it("should initialise the correct registry", async () => {
+      await titleEscrowContract.initialize(fakeRegistryAddress, fakeTokenId);
+
+      const res = await titleEscrowContract.registry();
+
+      expect(res).to.equal(fakeRegistryAddress);
+    });
+
+    it("should initialise the correct token ID", async () => {
+      await titleEscrowContract.initialize(fakeRegistryAddress, fakeTokenId);
+
+      const res = await titleEscrowContract.tokenId();
+
+      expect(res).to.equal(fakeTokenId);
+    });
+
+    it("should initialise domain separator correctly", async () => {
+      const hashDomain = ethers.utils._TypedDataEncoder.hashDomain(domain);
+      await titleEscrowContract.initialize(fakeRegistryAddress, fakeTokenId);
+
+      const res = await titleEscrowContract.DOMAIN_SEPARATOR();
+
+      expect(res).to.equal(hashDomain);
+    });
+  });
+
+  describe("Operational Behaviours", () => {
+    let fakeRegistryContract: FakeContract<TradeTrustERC721>;
+    let fakeTokenId: string;
+    let titleEscrowContractAsBeneficiary: TitleEscrowSignable;
+
+    beforeEach(async () => {
+      fakeRegistryContract = (await smock.fake("TradeTrustERC721")) as FakeContract<TradeTrustERC721>;
+
+      fakeTokenId = faker.datatype.hexaDecimal(64);
+      titleEscrowContractAsBeneficiary = titleEscrowContract.connect(users.beneficiary);
+
+      await titleEscrowContract.initialize(fakeRegistryContract.address, fakeTokenId);
+
+      await users.carrier.sendTransaction({
+        to: fakeRegistryContract.address,
+        value: ethers.utils.parseEther("0.1"),
+      });
+
+      const data = new ethers.utils.AbiCoder().encode(
+        ["address", "address"],
+        [users.beneficiary.address, users.holder.address]
+      );
+      await titleEscrowContract
+        .connect(fakeRegistryContract.wallet)
+        .onERC721Received(ethers.constants.AddressZero, ethers.constants.AddressZero, fakeTokenId, data);
+
+      fakeRegistryContract.ownerOf.returns(titleEscrowContract.address);
+    });
+
+    describe("Registry State Validations", () => {
+      const fakeEndorsement = {
+        beneficiary: faker.finance.ethereumAddress(),
+        holder: faker.finance.ethereumAddress(),
+        nominee: faker.finance.ethereumAddress(),
+        registry: faker.finance.ethereumAddress(),
+        tokenId: faker.datatype.hexaDecimal(64),
+        deadline: faker.datatype.number(),
+        nonce: 0,
+      };
+      const fakeSig = {
+        r: faker.datatype.hexaDecimal(64),
+        s: faker.datatype.hexaDecimal(64),
+        v: faker.datatype.number(10),
+      };
+
+      describe("When registry is paused", () => {
+        beforeEach(async () => {
+          fakeRegistryContract.paused.returns(true);
+        });
+
+        it("should revert when calling: transferBeneficiaryWithSig", async () => {
+          const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(fakeEndorsement, fakeSig);
+
+          await expect(tx).to.be.revertedWith("TE: Registry paused");
+        });
+
+        it("should revert when calling: cancelBeneficiaryTransfer", async () => {
+          const tx = titleEscrowContractAsBeneficiary.cancelBeneficiaryTransfer(fakeEndorsement);
+
+          await expect(tx).to.be.revertedWith("TE: Registry paused");
+        });
+      });
+
+      describe("When title escrow is inactive", () => {
+        beforeEach(async () => {
+          fakeRegistryContract.ownerOf.returns(faker.finance.ethereumAddress());
+          await titleEscrowContract.connect(fakeRegistryContract.wallet).shred();
+        });
+
+        it("should revert when calling: transferBeneficiaryWithSig", async () => {
+          const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(fakeEndorsement, fakeSig);
+
+          await expect(tx).to.be.revertedWith("TE: Inactive");
+        });
+
+        it("should revert when calling: cancelBeneficiaryTransfer", async () => {
+          const tx = titleEscrowContractAsBeneficiary.cancelBeneficiaryTransfer(fakeEndorsement);
+
+          await expect(tx).to.be.revertedWith("TE: Inactive");
+        });
+      });
+
+      describe("When title escrow is not holding token", () => {
+        beforeEach(async () => {
+          fakeRegistryContract.ownerOf.returns(faker.finance.ethereumAddress());
+        });
+
+        it("should revert when calling: transferBeneficiaryWithSig", async () => {
+          const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(fakeEndorsement, fakeSig);
+
+          await expect(tx).to.be.revertedWith("TE: Not holding token");
+        });
+
+        it("should call cancelBeneficiaryTransfer successfully", async () => {
+          fakeEndorsement.holder = users.holder.address;
+          const tx = titleEscrowContract.connect(users.holder).cancelBeneficiaryTransfer(fakeEndorsement);
+
+          await expect(tx).to.not.be.reverted;
+        });
+      });
+    });
+
+    describe("Transfer Beneficiary with Signature", () => {
+      let endorsement: BeneficiaryTransferData;
+      let nominee: SignerWithAddress;
+      let sig: Signature;
+      let hashStruct: string;
+
+      const beneficiaryTransferTypes = {
+        BeneficiaryTransfer: [
+          { name: "beneficiary", type: "address" },
+          { name: "holder", type: "address" },
+          { name: "nominee", type: "address" },
+          { name: "registry", type: "address" },
+          { name: "tokenId", type: "uint256" },
+          { name: "deadline", type: "uint256" },
+          { name: "nonce", type: "uint256" },
+        ],
+      };
+
+      beforeEach(async () => {
+        [nominee] = users.others;
+
+        endorsement = {
+          beneficiary: users.beneficiary.address,
+          holder: users.holder.address,
+          nominee: nominee.address,
+          registry: fakeRegistryContract.address,
+          tokenId: fakeTokenId,
+          deadline: Math.floor(Date.now() / 1000) + 3600 * 24,
+          nonce: 0,
+        };
+
+        const sigHash = await users.holder._signTypedData(domain, beneficiaryTransferTypes, endorsement);
+        sig = ethers.utils.splitSignature(sigHash);
+
+        hashStruct = ethers.utils.keccak256(
+          ethers.utils.defaultAbiCoder.encode(
+            ["bytes32", ...beneficiaryTransferTypes.BeneficiaryTransfer.map((obj) => obj.type)],
+            [
+              ethers.utils.id(
+                "BeneficiaryTransfer(address beneficiary,address holder,address nominee,address registry,uint256 tokenId,uint256 deadline,uint256 nonce)"
+              ),
+              ...Object.values(endorsement),
+            ]
+          )
+        );
+      });
+
+      describe("Beneficiary Transfer: transferBeneficiaryWithSig", () => {
+        describe("When Beneficiary Transfer signature is invalid", () => {
+          it("should revert when caller is not a beneficiary", async () => {
+            const tx = titleEscrowContract.connect(users.holder).transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Not beneficiary");
+          });
+
+          it("should revert if endorsed nominee is zero address", async () => {
+            endorsement.nominee = ethers.constants.AddressZero;
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Invalid endorsement");
+          });
+
+          it("should revert if endorsed nominee is same as beneficiary address", async () => {
+            endorsement.nominee = users.beneficiary.address;
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Invalid endorsement");
+          });
+
+          it("should revert if signer is not holder", async () => {
+            endorsement.holder = users.others[faker.datatype.number(users.others.length - 1)].address;
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Invalid endorsement");
+          });
+
+          it("should revert if endorsed token ID is in correct", async () => {
+            endorsement.tokenId = faker.datatype.hexaDecimal(64);
+            const sigHash = await users.holder._signTypedData(domain, beneficiaryTransferTypes, endorsement);
+            sig = ethers.utils.splitSignature(sigHash);
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Invalid endorsement");
+          });
+
+          it("should revert if endorsed registry is in correct", async () => {
+            endorsement.registry = faker.finance.ethereumAddress();
+            const sigHash = await users.holder._signTypedData(domain, beneficiaryTransferTypes, endorsement);
+            sig = ethers.utils.splitSignature(sigHash);
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Invalid endorsement");
+          });
+
+          it("should revert when on-chain nominee is different from endorsed nominee", async () => {
+            const [, invalidNominee] = users.others;
+            await titleEscrowContractAsBeneficiary.nominate(invalidNominee.address);
+            const onChainNominee = await titleEscrowContract.beneficiaryNominee();
+            assert(onChainNominee === invalidNominee.address, "Wrong on-chain nominee");
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Nominee mismatch");
+          });
+
+          it("should revert if beneficiary in endorsement is different from current beneficiary", async () => {
+            endorsement.beneficiary = users.others[faker.datatype.number(users.others.length - 1)].address;
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Beneficiary mismatch");
+          });
+
+          it("should revert if signature is expired", async () => {
+            endorsement.deadline = Math.floor(Date.now() / 1000) - 3600;
+            const sigHash = await users.holder._signTypedData(domain, beneficiaryTransferTypes, endorsement);
+            sig = ethers.utils.splitSignature(sigHash);
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Expired");
+          });
+
+          it("should revert if nonce is incorrect", async () => {
+            endorsement.nonce = faker.datatype.number();
+            const sigHash = await users.holder._signTypedData(domain, beneficiaryTransferTypes, endorsement);
+            sig = ethers.utils.splitSignature(sigHash);
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("TE: Invalid signature");
+          });
+        });
+
+        describe("When Beneficiary Transfer signature is valid", () => {
+          it("should transfer to nominated beneficiary successfully", async () => {
+            await titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+            const res = await titleEscrowContract.beneficiary();
+
+            expect(res).to.equal(nominee.address);
+          });
+
+          it("should transfer beneficiary successfully if on-chain nominee is same as endorsed nominee", async () => {
+            await titleEscrowContractAsBeneficiary.nominate(nominee.address);
+            const onChainNominee = await titleEscrowContract.beneficiaryNominee();
+            assert(onChainNominee === nominee.address, "On-chain nominee is different from endorsed nominee");
+
+            await titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+            const res = await titleEscrowContract.beneficiary();
+
+            expect(res).to.equal(nominee.address);
+          });
+
+          it("should increase holder nonce value after beneficiary transfer", async () => {
+            const initNonce = await titleEscrowContract.nonces(users.holder.address);
+            await titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            const currentNonce = await titleEscrowContract.nonces(users.holder.address);
+
+            expect(Number(currentNonce)).to.be.greaterThan(Number(initNonce));
+          });
+
+          it("should revert if Beneficiary Transfer is cancelled", async () => {
+            await titleEscrowContract.connect(users.holder).cancelBeneficiaryTransfer(endorsement);
+            const cancelStatus = await titleEscrowContract.cancelled(hashStruct);
+            assert(cancelStatus, "Beneficiary Transfer is not cancelled");
+
+            const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+            await expect(tx).to.be.revertedWith("Cancelled");
+          });
+        });
+
+        describe("Beneficiary Transfer Cancellation", () => {
+          let titleEscrowContractAsEndorsingHolder: TitleEscrowSignable;
+
+          beforeEach(async () => {
+            titleEscrowContractAsEndorsingHolder = titleEscrowContract.connect(users.holder);
+          });
+
+          it("should revert if caller is not holder who initiated endorsement", async () => {
+            const invalidHolder = users.others[faker.datatype.number(users.others.length - 1)];
+
+            const tx = titleEscrowContract.connect(invalidHolder).cancelBeneficiaryTransfer(endorsement);
+
+            await expect(tx).to.be.revertedWith("TE: Caller not endorser");
+          });
+
+          it("should add correct hash to cancel", async () => {
+            const initStatus = await titleEscrowContract.cancelled(hashStruct);
+            assert(!initStatus, "Initial cancel status should be false");
+
+            await titleEscrowContractAsEndorsingHolder.cancelBeneficiaryTransfer(endorsement);
+
+            const res = await titleEscrowContract.cancelled(hashStruct);
+
+            expect(res).to.be.true;
+          });
+
+          it("should emit CancelBeneficiaryTransferEndorsement event", async () => {
+            const tx = await titleEscrowContractAsEndorsingHolder.cancelBeneficiaryTransfer(endorsement);
+
+            expect(tx)
+              .to.emit(titleEscrowContractAsBeneficiary, "CancelBeneficiaryTransferEndorsement")
+              .withArgs(hashStruct, users.holder.address, fakeTokenId);
+          });
+        });
+      });
+
+      describe("When transferring holder", () => {
+        let newHolder: SignerWithAddress;
+
+        beforeEach(async () => {
+          newHolder = users.others[faker.datatype.number(users.others.length - 1)];
+        });
+
+        it("should increase nonce of previous holder", async () => {
+          const initNonce = await titleEscrowContract.nonces(users.holder.address);
+
+          await titleEscrowContract.connect(users.holder).transferHolder(newHolder.address);
+          const currentNonce = await titleEscrowContract.nonces(users.holder.address);
+
+          expect(Number(currentNonce)).to.be.greaterThan(Number(initNonce));
+        });
+
+        it("should not alter the nonce of new holder", async () => {
+          const initNonce = await titleEscrowContract.nonces(newHolder.address);
+
+          await titleEscrowContract.connect(users.holder).transferHolder(newHolder.address);
+          const currentNonce = await titleEscrowContract.nonces(newHolder.address);
+
+          expect(initNonce).to.equal(currentNonce);
+        });
+
+        it("should render existing signatures from previous holder invalid", async () => {
+          endorsement.holder = newHolder.address;
+          const sigHash = await users.holder._signTypedData(domain, beneficiaryTransferTypes, endorsement);
+          sig = ethers.utils.splitSignature(sigHash);
+          await titleEscrowContract.connect(users.holder).transferHolder(newHolder.address);
+
+          const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
+
+          await expect(tx).to.be.revertedWith("TE: Invalid signature");
+        });
+      });
+    });
+  });
+});

--- a/test/TitleEscrowSignable.test.ts
+++ b/test/TitleEscrowSignable.test.ts
@@ -8,6 +8,7 @@ import { FakeContract, smock } from "@defi-wonderland/smock";
 import { expect, assert } from ".";
 import { getTestUsers, TestUsers } from "./helpers";
 import { deployImplProxy } from "./fixtures/deploy-impl-proxy.fixture";
+import { contractInterfaceId } from "../src/constants";
 
 const { loadFixture } = waffle;
 
@@ -74,6 +75,22 @@ describe("TitleEscrowSignable", async () => {
       const res = await titleEscrowContract.BENEFICIARY_TRANSFER_TYPEHASH();
 
       expect(res).to.equal(typeHash);
+    });
+
+    it("should support TitleEscrowSignable interface", async () => {
+      const interfaceId = contractInterfaceId.TitleEscrowSignable;
+
+      const res = await titleEscrowContract.supportsInterface(interfaceId);
+
+      expect(res).to.be.true;
+    });
+
+    it("should support TitleEscrow interface", async () => {
+      const interfaceId = contractInterfaceId.TitleEscrow;
+
+      const res = await titleEscrowContract.supportsInterface(interfaceId);
+
+      expect(res).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Summary
Adds a new variant of the title escrow with support for off-chain endorsement of beneficiary nominees. 
This variant of the title escrow will currently be an experimental feature which users can optionally opt in to use if they want. This will not be the default Title Escrow in deployment for now.

## Changes
* Add `TitleEscrowSignable` contract
* Add test cases for `TitleEscrowSignable`

## Issues
- https://www.pivotaltracker.com/story/show/182754734

## Releases
Channels: beta
