### PR TITLE
feat: rename beneficiaryNominee to nominee

### DIFF
--- a/contracts/TitleEscrowSignable.sol
+++ b/contracts/TitleEscrowSignable.sol
@@ -51,9 +51,9 @@ contract TitleEscrowSignable is SigHelper, TitleEscrow, TitleEscrowSignableError
       revert InvalidEndorsement();
     }
 
-    if (beneficiaryNominee != address(0)) {
-      if (endorsement.nominee != beneficiaryNominee) {
-        revert MismatchedEndorsedNomineeAndOnChainNominee(endorsement.nominee, beneficiaryNominee);
+    if (nominee != address(0)) {
+      if (endorsement.nominee != nominee) {
+        revert MismatchedEndorsedNomineeAndOnChainNominee(endorsement.nominee, nominee);
       }
     }
 

--- a/contracts/interfaces/ITitleEscrow.sol
+++ b/contracts/interfaces/ITitleEscrow.sol
@@ -23,13 +23,13 @@ interface ITitleEscrow is IERC721Receiver {
   event Surrender(address indexed surrenderer, address registry, uint256 tokenId);
   event Shred(address registry, uint256 tokenId);
 
-  function nominate(address beneficiaryNominee) external;
+  function nominate(address nominee) external;
 
-  function transferBeneficiary(address beneficiaryNominee) external;
+  function transferBeneficiary(address nominee) external;
 
   function transferHolder(address newHolder) external;
 
-  function transferOwners(address beneficiaryNominee, address newHolder) external;
+  function transferOwners(address nominee, address newHolder) external;
 
   function beneficiary() external view returns (address);
 
@@ -37,7 +37,7 @@ interface ITitleEscrow is IERC721Receiver {
 
   function active() external view returns (bool);
 
-  function beneficiaryNominee() external view returns (address);
+  function nominee() external view returns (address);
 
   function registry() external view returns (address);
 

--- a/src/constants/contract-interfaces.ts
+++ b/src/constants/contract-interfaces.ts
@@ -14,7 +14,7 @@ export const contractInterfaces = {
     "beneficiary()",
     "holder()",
     "active()",
-    "beneficiaryNominee()",
+    "nominee()",
     "registry()",
     "tokenId()",
     "isHoldingToken()",

--- a/test/TitleEscrow.test.ts
+++ b/test/TitleEscrow.test.ts
@@ -121,7 +121,7 @@ describe("Title Escrow", async () => {
       });
 
       it("should initialise beneficiary nominee with zero", async () => {
-        expect(await titleEscrowContract.beneficiaryNominee()).to.equal(defaultAddress.Zero);
+        expect(await titleEscrowContract.nominee()).to.equal(defaultAddress.Zero);
       });
     });
 
@@ -451,16 +451,16 @@ describe("Title Escrow", async () => {
 
         it("should allow beneficiary to nominate a new beneficiary", async () => {
           await titleEscrowOwnerContract.connect(users.beneficiary).nominate(beneficiaryNominee.address);
-          const res = await titleEscrowOwnerContract.beneficiaryNominee();
+          const res = await titleEscrowOwnerContract.nominee();
 
           expect(res).to.equal(beneficiaryNominee.address);
         });
 
         it("should allow beneficiary to revoke beneficiary nomination", async () => {
           await titleEscrowOwnerContract.connect(users.beneficiary).nominate(beneficiaryNominee.address);
-          const initialNominee = await titleEscrowOwnerContract.beneficiaryNominee();
+          const initialNominee = await titleEscrowOwnerContract.nominee();
           await titleEscrowOwnerContract.connect(users.beneficiary).nominate(defaultAddress.Zero);
-          const revokedNominee = await titleEscrowOwnerContract.beneficiaryNominee();
+          const revokedNominee = await titleEscrowOwnerContract.nominee();
 
           expect(initialNominee).to.equal(beneficiaryNominee.address);
           expect(revokedNominee).to.equal(defaultAddress.Zero);
@@ -553,7 +553,7 @@ describe("Title Escrow", async () => {
             .mint(users.beneficiary.address, users.beneficiary.address, fakeTokenId);
           titleEscrowOwnerContract = await getTitleEscrowContract(registryContract, fakeTokenId);
 
-          const initialBeneficiaryNominee = await titleEscrowOwnerContract.beneficiaryNominee();
+          const initialBeneficiaryNominee = await titleEscrowOwnerContract.nominee();
           await titleEscrowOwnerContract
             .connect(users.beneficiary)
             .transferBeneficiary(targetNonBeneficiaryNominee.address);
@@ -592,7 +592,7 @@ describe("Title Escrow", async () => {
           await titleEscrowOwnerContract.connect(users.beneficiary).nominate(beneficiaryNominee.address);
 
           await titleEscrowOwnerContract.connect(users.holder).transferBeneficiary(beneficiaryNominee.address);
-          const res = await titleEscrowOwnerContract.beneficiaryNominee();
+          const res = await titleEscrowOwnerContract.nominee();
 
           await expect(res).to.equal(defaultAddress.Zero);
         });
@@ -632,7 +632,7 @@ describe("Title Escrow", async () => {
             .mint(users.beneficiary.address, users.beneficiary.address, fakeTokenId);
           titleEscrowOwnerContract = await getTitleEscrowContract(registryContract, fakeTokenId);
 
-          const initialBeneficiaryNominee = await titleEscrowOwnerContract.beneficiaryNominee();
+          const initialBeneficiaryNominee = await titleEscrowOwnerContract.nominee();
           await titleEscrowOwnerContract.connect(users.beneficiary).transferHolder(targetNonNominatedHolder.address);
           const currentHolder = await titleEscrowOwnerContract.holder();
 
@@ -763,10 +763,10 @@ describe("Title Escrow", async () => {
         const beneficiaryNominee = ethers.utils.getAddress(faker.finance.ethereumAddress());
         const titleEscrowAsBeneficiary = titleEscrowOwnerContract.connect(beneficiary);
         await titleEscrowAsBeneficiary.nominate(beneficiaryNominee);
-        const initialBeneficiaryNominee = await titleEscrowOwnerContract.beneficiaryNominee();
+        const initialBeneficiaryNominee = await titleEscrowOwnerContract.nominee();
 
         await titleEscrowAsBeneficiary.surrender();
-        const currentBeneficiaryNominee = await titleEscrowOwnerContract.beneficiaryNominee();
+        const currentBeneficiaryNominee = await titleEscrowOwnerContract.nominee();
 
         expect(initialBeneficiaryNominee).to.deep.equal(beneficiaryNominee);
         expect(currentBeneficiaryNominee).to.deep.equal(defaultAddress.Zero);
@@ -845,7 +845,7 @@ describe("Title Escrow", async () => {
         await titleEscrowOwnerContract.connect(users.beneficiary).surrender();
 
         await titleEscrowOwnerContract.connect(registrySigner).shred();
-        const res = await titleEscrowOwnerContract.beneficiaryNominee();
+        const res = await titleEscrowOwnerContract.nominee();
 
         expect(res).to.equal(defaultAddress.Zero);
       });

--- a/test/TitleEscrowSignable.test.ts
+++ b/test/TitleEscrowSignable.test.ts
@@ -338,7 +338,7 @@ describe("TitleEscrowSignable", async () => {
           it("should revert when on-chain nominee is different from endorsed nominee", async () => {
             const [, invalidNominee] = users.others;
             await titleEscrowContractAsBeneficiary.nominate(invalidNominee.address);
-            const onChainNominee = await titleEscrowContract.beneficiaryNominee();
+            const onChainNominee = await titleEscrowContract.nominee();
             assert(onChainNominee === invalidNominee.address, "Wrong on-chain nominee");
 
             const tx = titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);
@@ -395,7 +395,7 @@ describe("TitleEscrowSignable", async () => {
 
           it("should transfer beneficiary successfully if on-chain nominee is same as endorsed nominee", async () => {
             await titleEscrowContractAsBeneficiary.nominate(nominee.address);
-            const onChainNominee = await titleEscrowContract.beneficiaryNominee();
+            const onChainNominee = await titleEscrowContract.nominee();
             assert(onChainNominee === nominee.address, "On-chain nominee is different from endorsed nominee");
 
             await titleEscrowContractAsBeneficiary.transferBeneficiaryWithSig(endorsement, sig);


### PR DESCRIPTION
## Summary
Rename `beneficiaryNominee` to `nominee` for brevity and consistency.

## Changes
* Rename `beneficiaryNominee` to `nominee`
* Update tests

## Issues
N.A.

## Releases
Channels: beta
