### PR TITLE
fix: contracts zero address to undefined

### DIFF
--- a/src/constants/contract-address.ts
+++ b/src/constants/contract-address.ts
@@ -1,5 +1,3 @@
-import { defaultAddress } from "./default-address";
-
 const ChainId = {
   Ethereum: 1,
   Ropsten: 3,
@@ -12,30 +10,30 @@ const ChainId = {
 
 export const contractAddress = {
   TitleEscrowFactory: {
-    [ChainId.Ethereum]: defaultAddress.Zero,
+    [ChainId.Ethereum]: undefined,
     [ChainId.Rinkeby]: "0x878A327daA390Bc602Ae259D3A374610356b6485",
     [ChainId.Ropsten]: "0x878A327daA390Bc602Ae259D3A374610356b6485",
-    [ChainId.Goerli]: defaultAddress.Zero,
-    [ChainId.Kovan]: defaultAddress.Zero,
-    [ChainId.Polygon]: defaultAddress.Zero,
+    [ChainId.Goerli]: undefined,
+    [ChainId.Kovan]: undefined,
+    [ChainId.Polygon]: undefined,
     [ChainId.PolygonMumbai]: "0x878A327daA390Bc602Ae259D3A374610356b6485",
   },
   Deployer: {
-    [ChainId.Ethereum]: defaultAddress.Zero,
+    [ChainId.Ethereum]: undefined,
     [ChainId.Rinkeby]: "0x021C1e895e39D53Cf87722211FF0a824d9D73c60",
     [ChainId.Ropsten]: "0x9eBC30E7506E6Ce36eAc5507FCF0121BaF7AeA57",
-    [ChainId.Goerli]: defaultAddress.Zero,
-    [ChainId.Kovan]: defaultAddress.Zero,
-    [ChainId.Polygon]: defaultAddress.Zero,
+    [ChainId.Goerli]: undefined,
+    [ChainId.Kovan]: undefined,
+    [ChainId.Polygon]: undefined,
     [ChainId.PolygonMumbai]: "0x9eBC30E7506E6Ce36eAc5507FCF0121BaF7AeA57",
   },
   TokenImplementation: {
-    [ChainId.Ethereum]: defaultAddress.Zero,
+    [ChainId.Ethereum]: undefined,
     [ChainId.Rinkeby]: "0x83A533397eFE1d90baA26dEc7743626d7598656F",
     [ChainId.Ropsten]: "0xE5C75026d5f636C89cc77583B6BCe7C99F512763",
-    [ChainId.Goerli]: defaultAddress.Zero,
-    [ChainId.Kovan]: defaultAddress.Zero,
-    [ChainId.Polygon]: defaultAddress.Zero,
+    [ChainId.Goerli]: undefined,
+    [ChainId.Kovan]: undefined,
+    [ChainId.Polygon]: undefined,
     [ChainId.PolygonMumbai]: "0xE5C75026d5f636C89cc77583B6BCe7C99F512763",
   },
 };


### PR DESCRIPTION
## Summary
The unsupported network contracts were set as zero address instead of undefined. This results in transactions being sent to `0x0` as it misses the check in the deployer when it should really have failed with an error.

This PR fixes the deployment for unsupported networks to not proceed and show the correct error message:
![image](https://user-images.githubusercontent.com/2247766/191195309-e440ded8-e453-4ef3-9c13-299c1f9d4df9.png)


## Changes
* Replace zero address to undefined for contract addresses

## Issues
- https://github.com/Open-Attestation/open-attestation/discussions/240#discussioncomment-3680035

## Releases
Channels: beta
