### PR TITLE
docs: update network names in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ For users who want to quickly deploy their contracts without too much hassle, yo
 npx hardhat deploy:token --network mumbai --name "The Great Shipping Co." --symbol GSC
 ```
 
-👆 This is the easiest and most cost-effective method to deploy. Currently, this is supported on Goerli, Sepolia and Polygon Mumbai. The deployed contract will inherit all the standard functionality from our on-chain contracts. This helps to save deployment costs and make the process more convenient for users and integrators.
+👆 This is the easiest and most cost-effective method to deploy. Currently, this is supported on Ethereum, Goerli, Sepolia, Polygon and Polygon Mumbai. The deployed contract will inherit all the standard functionality from our on-chain contracts. This helps to save deployment costs and make the process more convenient for users and integrators.
 
 > 💡 Remember to supply the`--network` argument with the name of the network you wish to deploy on.
 > See [Network Configuration](#network-configuration) section for more info on the list of network names.


### PR DESCRIPTION
## Summary
Update the description for Quick Start in the readme that is missing Ethereum and Polygon networks.

## Changes
* Update description in readme

## Issues
NIL

## Releases
Channels: latest
