### PR TITLE
fix: title escrow factory create call

### DIFF
--- a/contracts/TitleEscrowFactory.sol
+++ b/contracts/TitleEscrowFactory.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "./TitleEscrow.sol";
 import "./interfaces/ITitleEscrowFactory.sol";
+import "./interfaces/TitleEscrowFactoryErrors.sol";
 
-contract TitleEscrowFactory is ITitleEscrowFactory {
+contract TitleEscrowFactory is ITitleEscrowFactory, TitleEscrowFactoryErrors {
   address public override implementation;
 
   constructor() {
@@ -13,6 +14,9 @@ contract TitleEscrowFactory is ITitleEscrowFactory {
   }
 
   function create(uint256 tokenId) external override returns (address) {
+    if (msg.sender.code.length == 0) {
+      revert CreateCallerNotContract();
+    }
     bytes32 salt = keccak256(abi.encodePacked(msg.sender, tokenId));
     address titleEscrow = Clones.cloneDeterministic(implementation, salt);
     TitleEscrow(titleEscrow).initialize(msg.sender, tokenId);

--- a/contracts/interfaces/TitleEscrowFactoryErrors.sol
+++ b/contracts/interfaces/TitleEscrowFactoryErrors.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+interface TitleEscrowFactoryErrors {
+  error CreateCallerNotContract();
+}

--- a/contracts/mocks/DummyContractMock.sol
+++ b/contracts/mocks/DummyContractMock.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+contract DummyContractMock {
+
+  string public name = "Dummy";
+
+  constructor() {}
+}


### PR DESCRIPTION
## Summary
Add a requirement that the caller creating the title escrow must be a contract.

## Changes
* Require caller to create title escrow a contract

## Issues
- https://www.pivotaltracker.com/story/show/183445132

## Releases
Channels: latest
