### PR TITLE
fix: caller for create in title escrow factory

### DIFF
--- a/contracts/TitleEscrowFactory.sol
+++ b/contracts/TitleEscrowFactory.sol
@@ -14,7 +14,7 @@ contract TitleEscrowFactory is ITitleEscrowFactory, TitleEscrowFactoryErrors {
   }
 
   function create(uint256 tokenId) external override returns (address) {
-    if (msg.sender.code.length == 0) {
+    if (tx.origin == msg.sender) {
       revert CreateCallerNotContract();
     }
     bytes32 salt = keccak256(abi.encodePacked(msg.sender, tokenId));

--- a/contracts/mocks/DummyContractMock.sol
+++ b/contracts/mocks/DummyContractMock.sol
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
-
-contract DummyContractMock {
-
-  string public name = "Dummy";
-
-  constructor() {}
-}

--- a/contracts/mocks/TitleEscrowFactoryCallerMock.sol
+++ b/contracts/mocks/TitleEscrowFactoryCallerMock.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../interfaces/ITitleEscrowFactory.sol";
+
+contract TitleEscrowFactoryCallerMock {
+  function callCreate(address titleEscrowFactory, uint256 tokenId) public {
+    ITitleEscrowFactory(titleEscrowFactory).create(tokenId);
+  }
+}


### PR DESCRIPTION
## Summary
Fix caller check for `create` in Title Escrow Factory.

## Changes
* Update caller check for `create` to restrict to only contracts

## Issues
- https://www.pivotaltracker.com/story/show/183445132

## Releases
Channels: latest
